### PR TITLE
fix fit="clip" + width xor height explicitly set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,13 +81,22 @@ export default class ReactImgix extends Component {
     if (this.props.fit) fit = this.props.fit
 
     if (this.state.mounted || this.props.aggresiveLoad) {
-      const srcOptions = {
+      let srcOptions = {
         auto: this.props.auto,
         ...this.props.customParams,
         crop,
         fit,
         width,
         height
+      }
+      
+      if (fit === 'clip') {
+        if (this.props.width && !this.props.height) {
+          delete srcOptions.height
+        }
+        if (this.props.height && !this.props.width) {
+          delete srcOptions.width
+        }
       }
 
       src = processImage(this.props.src, srcOptions)


### PR DESCRIPTION
if fit="clip" is set and one explicitly provides height xor width the component should not try to measure/compute the width xor height and send that value down.

a problem arises in cases where we do not know beforehand out elements height (which depends on the images' height which can only be know once the image is loaded) but we do know the elements width and we'd like an optimised image which preserves aspect ratio..

the code so far would still try to mesure height if fit="clip" and width is set (lets say 400) (but not height) and because it is unknown beforehand the value is incorrect (rounded up to the 100th be default.) so we end up with the imgix url params being "fit=clip&w=400&h=100"

i fixed this by removing the measured height xor width when width xor height is set and fit="clip"

i only did this for "clip" for now but there might be other situations in which this problem arises.. but i guess you guys would know better :)