### PR TITLE
Strip protocol

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,10 +82,10 @@ export default class ReactImgix extends Component {
       customParams,
       entropy,
       faces,
-      src,
-      stripProtocol,
       fit,
       generateSrcSet,
+      src,
+      stripProtocol,
       ...other
     } = this.props
     let _src = ''

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ export default class ReactImgix extends Component {
     fit: PropTypes.string,
     auto: PropTypes.array,
     faces: PropTypes.bool,
+    stripProtocol: PropTypes.bool,
     aggresiveLoad: PropTypes.bool,
     fluid: PropTypes.bool,
     children: PropTypes.any,
@@ -44,6 +45,7 @@ export default class ReactImgix extends Component {
     fluid: true,
     aggresiveLoad: false,
     faces: true,
+    stripProtocol: false,
     fit: 'crop',
     entropy: false,
     auto: ['format'],
@@ -80,11 +82,12 @@ export default class ReactImgix extends Component {
       customParams,
       entropy,
       faces,
+      stripProtocol,
       fit,
       generateSrcSet,
-      src,
       ...other
     } = this.props
+    let src = this.props.src
     let _src = ''
     let srcSet = ''
     let _component = component
@@ -109,6 +112,10 @@ export default class ReactImgix extends Component {
         width,
         height
       }
+
+      // Match first instance of <anything>:// in the string
+      const protocolMatch = new RegExp(/^.*?:\/\//)
+      if (stripProtocol) src = src.replace(protocolMatch, '//')
 
       _src = processImage(src, srcOptions)
       const dpr2 = processImage(src, {...srcOptions, dpr: 2})

--- a/src/index.js
+++ b/src/index.js
@@ -82,12 +82,12 @@ export default class ReactImgix extends Component {
       customParams,
       entropy,
       faces,
+      src,
       stripProtocol,
       fit,
       generateSrcSet,
       ...other
     } = this.props
-    let src = this.props.src
     let _src = ''
     let srcSet = ''
     let _component = component
@@ -113,15 +113,15 @@ export default class ReactImgix extends Component {
         height
       }
 
-      // Match first instance of <anything>:// in the string
-      const protocolMatch = new RegExp(/^.*?:\/\//)
-      if (stripProtocol) src = src.replace(protocolMatch, '//')
-
       _src = processImage(src, srcOptions)
       const dpr2 = processImage(src, {...srcOptions, dpr: 2})
       const dpr3 = processImage(src, {...srcOptions, dpr: 3})
       srcSet = `${dpr2} 2x, ${dpr3} 3x`
     }
+
+    // Match first instance of <anything>:// in the string
+    const protocolMatch = new RegExp(/^.*?:\/\//)
+    if (stripProtocol) _src = _src.replace(protocolMatch, '//')
 
     let childProps = other
 

--- a/src/index.js
+++ b/src/index.js
@@ -119,9 +119,9 @@ export default class ReactImgix extends Component {
       srcSet = `${dpr2} 2x, ${dpr3} 3x`
     }
 
-    // Match first instance of <anything>:// in the string
-    const protocolMatch = new RegExp(/^.*?:\/\//)
-    if (stripProtocol) _src = _src.replace(protocolMatch, '//')
+    // Match first instance of <anything>:// in a string
+    const matchProtocol = new RegExp(/^.*?:\/\//)
+    if (stripProtocol) _src = _src.replace(matchProtocol, '//')
 
     let childProps = other
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -151,6 +151,19 @@ describe('image props', () => {
 
     expect(vdom.props.src).toEqual('https://mysource.imgix.net/~text?auto=format&dpr=1&txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE&crop=faces&fit=crop&w=1&h=1')
   })
+  it('strip protocol if stripProtocol attribute is present', () => {
+    tree = sd.shallowRender(
+      <Imgix
+        src={'https://mysource.imgix.net/demo.png'}
+        aggresiveLoad
+        stripProtocol
+      />
+    )
+    vdom = tree.getRenderOutput()
+
+    const protocolIndex = vdom.props.src.indexOf('//mysource.imgix.net/demo.png')
+    expect(protocolIndex).toBe(0)
+  })
   // it('fluid prop', () => {
   //   expect(vdom.props.src).to.include('auto=format,enhance')
   // })


### PR DESCRIPTION
### Purpose

This PR implements the `stripProtocol` property that was discussed in https://github.com/imgix/react-imgix/issues/21. If it's truthy, the component will strip the protocol from the `src` attribute passed to it.

### Example
```jsx
<Imgix
  src={'https://mysource.imgix.net/demo.png'}
  stripProtocol
/>
```
would transform the url string into  `//mysource.imgix.net/demo.png`

The specific protocol is not checked so `foobar://mysource.imgix.net/demo.png`
would also be stripped to `//mysource.imgix.net/demo.png` and make a valid request.