### PR TITLE
Fix #25

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,11 @@ export default class ReactImgix extends Component {
       srcSet = `${dpr2} 2x, ${dpr3} 3x`
     }
 
-    let childProps = other
+    let childProps = {
+      ...other,
+      width: null,
+      height: null
+    }
 
     if (bg) {
       if (!component) {


### PR DESCRIPTION
This fix prevents the `width` and `height` passed down as props to the rendered element. So the dimensions of the `img` tag will not be overwritten unexpectedly. See #25 for more details.