### PR TITLE
Fix #25

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,8 +118,8 @@ export default class ReactImgix extends Component {
 
     let childProps = {
       ...other,
-      width: null,
-      height: null
+      width: other.width <= 1 ? null : other.width,
+      height: other.height <= 1 ? null : other.height
     }
 
     if (bg) {

--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,11 @@ export default class ReactImgix extends Component {
       srcSet = `${dpr2} 2x, ${dpr3} 3x`
     }
 
-    let childProps = other
+    let childProps = {
+      ...other,
+      width: null,
+      height: null
+    }
 
     if (bg) {
       if (!component) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -187,8 +187,8 @@ describe('image props', () => {
     expect(vdom.props.src).toEqual(`https://mysource.imgix.net/demo.png?auto=format&dpr=1&crop=faces&fit=crop&w=1&h=${height}`)
   })
 
-  it('height not passed to childProps', () => {
-    const height = 300
+  it('height between 0 and 1 not passed to childProps', () => {
+    const height = 0.5
     tree = sd.shallowRender(
       <Imgix
         src={'https://mysource.imgix.net/demo.png'}
@@ -199,6 +199,20 @@ describe('image props', () => {
     vdom = tree.getRenderOutput()
 
     expect(vdom.props.height).toBeFalsy()
+  })
+
+  it('height greater than 1 passed to childProps', () => {
+    const height = 300
+    tree = sd.shallowRender(
+      <Imgix
+        src={'https://mysource.imgix.net/demo.png'}
+        aggressiveLoad
+        height={height}
+      />
+    )
+    vdom = tree.getRenderOutput()
+
+    expect(vdom.props.height).toEqual(height)
   })
 
   it('width passed to url param', () => {
@@ -215,8 +229,8 @@ describe('image props', () => {
     expect(vdom.props.src).toEqual(`https://mysource.imgix.net/demo.png?auto=format&dpr=1&crop=faces&fit=crop&w=${width}&h=1`)
   })
 
-  it('width not passed to childProps', () => {
-    const width = 300
+  it('width between 0 and 1 not passed to childProps', () => {
+    const width = 0.5
     tree = sd.shallowRender(
       <Imgix
         src={'https://mysource.imgix.net/demo.png'}
@@ -227,5 +241,19 @@ describe('image props', () => {
     vdom = tree.getRenderOutput()
 
     expect(vdom.props.width).toBeFalsy()
+  })
+
+  it('width greater than 1 passed to childProps', () => {
+    const width = 300
+    tree = sd.shallowRender(
+      <Imgix
+        src={'https://mysource.imgix.net/demo.png'}
+        aggressiveLoad
+        width={width}
+      />
+    )
+    vdom = tree.getRenderOutput()
+
+    expect(vdom.props.width).toEqual(width)
   })
 })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -173,4 +173,59 @@ describe('image props', () => {
     expect(vdom.props.srcSet).toInclude('dpr=2')
     expect(vdom.props.srcSet).toInclude('dpr=3')
   })
+  it('height passed to url param', () => {
+    const height = 300
+    tree = sd.shallowRender(
+      <Imgix
+        src={'https://mysource.imgix.net/demo.png'}
+        aggressiveLoad
+        height={height}
+      />
+    )
+    vdom = tree.getRenderOutput()
+
+    expect(vdom.props.src).toEqual(`https://mysource.imgix.net/demo.png?auto=format&dpr=1&crop=faces&fit=crop&w=1&h=${height}`)
+  })
+
+  it('height not passed to childProps', () => {
+    const height = 300
+    tree = sd.shallowRender(
+      <Imgix
+        src={'https://mysource.imgix.net/demo.png'}
+        aggressiveLoad
+        height={height}
+      />
+    )
+    vdom = tree.getRenderOutput()
+
+    expect(vdom.props.height).toBeFalsy()
+  })
+
+  it('width passed to url param', () => {
+    const width = 300
+    tree = sd.shallowRender(
+      <Imgix
+        src={'https://mysource.imgix.net/demo.png'}
+        aggressiveLoad
+        width={width}
+      />
+    )
+    vdom = tree.getRenderOutput()
+
+    expect(vdom.props.src).toEqual(`https://mysource.imgix.net/demo.png?auto=format&dpr=1&crop=faces&fit=crop&w=${width}&h=1`)
+  })
+
+  it('width not passed to childProps', () => {
+    const width = 300
+    tree = sd.shallowRender(
+      <Imgix
+        src={'https://mysource.imgix.net/demo.png'}
+        aggressiveLoad
+        width={width}
+      />
+    )
+    vdom = tree.getRenderOutput()
+
+    expect(vdom.props.width).toBeFalsy()
+  })
 })


### PR DESCRIPTION
This fix prevents the width and height passed down as props to the rendered element. So the dimensions of the img tag will not be overwritten unexpectedly. See #25 for more details.