### PR TITLE
Enable passing in specific crop options, useful for fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ import Imgix from 'react-imgix'
   className={string}
   entropy={bool} // whether or not to crop using points of interest. See Imgix API for more details. Defaults to false
   faces={bool} // whether to crop to faces, defaults to true
+  crop={string} // sets specific crop, overriding faces and entropy flags. Useful for specifying fallbacks for faces like 'faces,top,right'
   fit={string} // see Imgix's API, defaults to 'crop'
   fluid={bool} // whether to fit the image requested to the size of the component rendered, defaults to true
   precision={number} // round to nearest x for image width and height, useful for caching, defaults to 100

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ export default class ReactImgix extends Component {
     component: PropTypes.string,
     fit: PropTypes.string,
     auto: PropTypes.array,
+    crop: PropTypes.string,
     faces: PropTypes.bool,
     aggressiveLoad: PropTypes.bool,
     fluid: PropTypes.bool,
@@ -80,6 +81,7 @@ export default class ReactImgix extends Component {
       children,
       component,
       customParams,
+      crop,
       entropy,
       faces,
       fit,
@@ -94,9 +96,10 @@ export default class ReactImgix extends Component {
     let width = this._findSizeForDimension('width')
     let height = this._findSizeForDimension('height')
 
-    let crop = false
-    if (faces) crop = 'faces'
-    if (entropy) crop = 'entropy'
+    let _crop = false
+    if (faces) _crop = 'faces'
+    if (entropy) _crop = 'entropy'
+    if (crop) _crop = crop
 
     let _fit = false
     if (entropy) _fit = 'crop'
@@ -106,7 +109,7 @@ export default class ReactImgix extends Component {
       const srcOptions = {
         auto: auto,
         ...customParams,
-        crop,
+        crop: _crop,
         fit: _fit,
         width,
         height

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -121,6 +121,19 @@ describe('image props', () => {
   it('className prop', () => {
     expect(vdom.props.className).toInclude(className)
   })
+  it('crop prop', () => {
+    tree = sd.shallowRender(
+      <Imgix
+        src={src}
+        aggressiveLoad
+        crop='faces,entropy'
+      />
+    )
+    vdom = tree.getRenderOutput()
+
+    expect(vdom.props.src).toInclude('crop=faces%2Centropy')
+    expect(vdom.props.src).toInclude('fit=crop')
+  })
   it('faces prop', () => {
     expect(vdom.props.src).toInclude('crop=faces')
   })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -134,6 +134,34 @@ describe('image props', () => {
     expect(vdom.props.src).toInclude('crop=faces%2Centropy')
     expect(vdom.props.src).toInclude('fit=crop')
   })
+  it('crop prop overrides faces prop', () => {
+    tree = sd.shallowRender(
+      <Imgix
+        src={src}
+        aggressiveLoad
+        faces
+        crop='faces,entropy'
+      />
+    )
+    vdom = tree.getRenderOutput()
+
+    expect(vdom.props.src).toInclude('crop=faces%2Centropy')
+    expect(vdom.props.src).toInclude('fit=crop')
+  })
+  it('crop prop overrides entropy prop', () => {
+    tree = sd.shallowRender(
+      <Imgix
+        src={src}
+        aggressiveLoad
+        entropy
+        crop='faces,entropy'
+      />
+    )
+    vdom = tree.getRenderOutput()
+
+    expect(vdom.props.src).toInclude('crop=faces%2Centropy')
+    expect(vdom.props.src).toInclude('fit=crop')
+  })
   it('faces prop', () => {
     expect(vdom.props.src).toInclude('crop=faces')
   })


### PR DESCRIPTION
The Imgix docs [describes passing multiple options](https://docs.imgix.com/apis/url/size/crop) to the 'crop' parameter, useful for providing fallbacks to the 'faces' crop. This PR enables doing that by exposing the 'crop' param as an optional string parameter. Passing in a specific 'crop' attribute, overrides the 'faces' and 'entropy' flags.