### PR TITLE
fix typo - deprecated warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export default class ReactImgix extends Component {
     // we don't set this in defaultProps because then just referencing the variable
     // prints the deprecation notice and we only ever check for truthiness so
     // undefined and false are close enough.
-    bg: deprecate(PropTypes.bool, 'bg is depracated, use type="bg" instead'),
+    bg: deprecate(PropTypes.bool, 'bg is deprecated, use type="bg" instead'),
     children: PropTypes.any,
     className: PropTypes.string,
     component: PropTypes.string,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -255,7 +255,7 @@ describe('background mode', () => {
   // this test has to come first since react-is-deprecated only prints a warning
   // the first time it's called
   it('should print deprecation error', () => {
-    sinon.assert.calledWithExactly(console.warn, 'bg is depracated, use type="bg" instead')
+    sinon.assert.calledWithExactly(console.warn, 'bg is deprecated, use type="bg" instead')
   })
 
   shouldBehaveLikeBg()


### PR DESCRIPTION
Noticed a typo in the deprecation warning for the `bg` prop