### PR TITLE
Background Size adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ what kind of component to render, one of `img`, `bg`, `picture`, `source`. Defau
 _DEPRECATED, use `type='bg'` instead_. whether to render the image as a background of the component, defaults to `false`.  
 _To be deprecated in v6._
 
-#### backgroundSize={string}
-Allow overriding the backgroundStyle property applied to the component when rendering a `bg`, defaults to `cover`.
-
 #### component={string}
 wrapper component to use when rendering a `bg`, defaults to `div`
 
@@ -75,6 +72,15 @@ any other Imgix params to add to the image `src`
 
 #### imgProps={object}
 any other attributes to add to the html node (example: `alt`, `data-*`, `className`)
+
+_Note_: if you use type='bg' the css property background-size is set to 'cover' by default. To override this behaviour you can change the background Size by overriding it with a string such as `'contain'`, or to `null` for controlling the style with CSS. 
+
+```js
+<Imgix
+    src={src}
+    type='bg'
+    imgProps={{style: {backgroundSize: 'contain'}}}/>
+ ```
 
 ### Picture Support
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ any other Imgix params to add to the image `src`
 #### imgProps={object}
 any other attributes to add to the html node (example: `alt`, `data-*`, `className`)
 
-_Note_: if you use type='bg' the css property background-size is set to 'cover' by default. To override this behaviour you can change the background Size by overriding it with a string such as `'contain'`, or to `null` for controlling the style with CSS. 
+_Note_: if you use type='bg' the css property background-size is set to 'cover' by default. To override this behaviour you can change the background size by overriding it with a string such as `'contain'`, or to `null` for controlling the style with CSS. 
 
 ```js
 <Imgix

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ what kind of component to render, one of `img`, `bg`, `picture`, `source`. Defau
 _DEPRECATED, use `type='bg'` instead_. whether to render the image as a background of the component, defaults to `false`.  
 _To be deprecated in v6._
 
+#### backgroundSize={string}
+Allow overriding the backgroundStyle property applied to the component when rendering a `bg`, defaults to `cover`.
+
 #### component={string}
 wrapper component to use when rendering a `bg`, defaults to `div`
 

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ export default class ReactImgix extends Component {
     faces: PropTypes.bool,
     fit: PropTypes.string,
     fluid: PropTypes.bool,
+    backgroundSize: PropTypes.string,
     generateSrcSet: PropTypes.bool,
     src: PropTypes.string.isRequired,
     type: PropTypes.oneOf(validTypes)
@@ -54,6 +55,7 @@ export default class ReactImgix extends Component {
   static defaultProps = {
     aggressiveLoad: false,
     auto: ['format'],
+    backgroundSize: 'cover',
     entropy: false,
     faces: true,
     fit: 'crop',
@@ -88,6 +90,7 @@ export default class ReactImgix extends Component {
       aggressiveLoad,
       auto,
       bg,
+      backgroundSize,
       children,
       component,
       customParams,
@@ -150,7 +153,7 @@ export default class ReactImgix extends Component {
         }
         childProps.style = {
           ...childProps.style,
-          backgroundSize: 'cover',
+          backgroundSize: backgroundSize,
           backgroundImage: isStringNotEmpty(_src) ? `url(${_src})` : null
         }
         break

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,6 @@ export default class ReactImgix extends Component {
     faces: PropTypes.bool,
     fit: PropTypes.string,
     fluid: PropTypes.bool,
-    backgroundSize: PropTypes.string,
     generateSrcSet: PropTypes.bool,
     src: PropTypes.string.isRequired,
     type: PropTypes.oneOf(validTypes)
@@ -55,7 +54,6 @@ export default class ReactImgix extends Component {
   static defaultProps = {
     aggressiveLoad: false,
     auto: ['format'],
-    backgroundSize: 'cover',
     entropy: false,
     faces: true,
     fit: 'crop',
@@ -90,7 +88,6 @@ export default class ReactImgix extends Component {
       aggressiveLoad,
       auto,
       bg,
-      backgroundSize,
       children,
       component,
       customParams,
@@ -152,9 +149,9 @@ export default class ReactImgix extends Component {
           _component = 'div'
         }
         childProps.style = {
-          ...childProps.style,
-          backgroundSize: backgroundSize,
-          backgroundImage: isStringNotEmpty(_src) ? `url(${_src})` : null
+          backgroundSize: 'cover',
+          backgroundImage: isStringNotEmpty(_src) ? `url(${_src})` : null,
+          ...childProps.style
         }
         break
       case 'img':

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -232,13 +232,29 @@ describe('background type', () => {
   shouldBehaveLikeBg()
 })
 
-describe('background type with backgroundSize', () => {
+describe('background type without backgroundSize', () => {
   beforeEach(() => {
     tree = sd.shallowRender(
       <Imgix
         src={src}
         type='bg'
-        backgroundSize="contain"
+        imgProps={{style: {backgroundSize: null}}}
+        aggressiveLoad
+      />
+    )
+    vdom = tree.getRenderOutput()
+    instance = tree.getMountedInstance()
+  })
+  shouldBehaveLikeBg(null)
+})
+
+describe('background type with background contain', () => {
+  beforeEach(() => {
+    tree = sd.shallowRender(
+      <Imgix
+        src={src}
+        type='bg'
+        imgProps={{style: {backgroundSize: 'contain'}}}
         aggressiveLoad
       />
     )

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -207,13 +207,13 @@ describe('<picture> type', () => {
   })
 })
 
-const shouldBehaveLikeBg = function () {
+const shouldBehaveLikeBg = function (size = 'cover') {
   it('should render a div', () => {
     expect(vdom.type).toBe('div')
   })
   it('should have the appropriate styles', () => {
     expect(vdom.props.style.backgroundImage).toInclude(src)
-    expect(vdom.props.style.backgroundSize).toBe('cover')
+    expect(vdom.props.style.backgroundSize).toBe(size)
   })
 }
 
@@ -230,6 +230,22 @@ describe('background type', () => {
     instance = tree.getMountedInstance()
   })
   shouldBehaveLikeBg()
+})
+
+describe('background type with backgroundSize', () => {
+  beforeEach(() => {
+    tree = sd.shallowRender(
+      <Imgix
+        src={src}
+        type='bg'
+        backgroundSize="contain"
+        aggressiveLoad
+      />
+    )
+    vdom = tree.getRenderOutput()
+    instance = tree.getMountedInstance()
+  })
+  shouldBehaveLikeBg('contain')
 })
 
 // same as above but with bg prop instead of type='bg'


### PR DESCRIPTION
We had to specify some custom background sizing on some components with CSS. This was difficult, because the background size was directly applied to the style.