### PR TITLE
add onMounted callback with access to underlying node

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ see Imgix's API, defaults to `crop`
 #### fluid={bool}
 whether to fit the image requested to the size of the component rendered, defaults to `true`
 
+#### onMounted={func}
+called on `componentDidMount` with the mounted DOM node as an argument
+
 #### precision={number}
 round to nearest x for image width and height, useful for caching, defaults to `100`
 

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ export default class ReactImgix extends Component {
     fit: PropTypes.string,
     fluid: PropTypes.bool,
     generateSrcSet: PropTypes.bool,
+    onMounted: PropTypes.func,
     src: PropTypes.string.isRequired,
     type: PropTypes.oneOf(validTypes)
   };
@@ -59,6 +60,7 @@ export default class ReactImgix extends Component {
     fit: 'crop',
     fluid: true,
     generateSrcSet: true,
+    onMounted: () => {},
     precision: 100,
     type: 'img'
   };
@@ -75,6 +77,7 @@ export default class ReactImgix extends Component {
       height: node.scrollHeight,
       mounted: true
     })
+    this.props.onMounted(node)
   };
 
   componentDidMount = () => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -5,6 +5,7 @@ import expectJSX from 'expect-jsx'
 import sinon from 'sinon'
 import sd from 'skin-deep'
 import React from 'react'
+import ReactDOM from 'react-dom'
 
 import Imgix from './index.js'
 
@@ -571,5 +572,24 @@ describe('image props', () => {
 
     expect(vdom.props.alt).toEqual(imgProps.alt)
     expect(vdom.props['data-src']).toEqual(imgProps['data-src'])
+  })
+
+  it('onMounted callback is called', () => {
+    const onMountedSpy = sinon.spy()
+    const mockImage = <img />
+
+    tree = sd.shallowRender(
+      <Imgix
+        src={'https://mysource.imgix.net/demo.png'}
+        onMounted={onMountedSpy}
+      />
+    )
+    instance = tree.getMountedInstance()
+    sinon.stub(ReactDOM, 'findDOMNode', () => (mockImage))
+    instance.componentDidMount()
+
+    sinon.assert.calledWith(onMountedSpy, mockImage)
+
+    ReactDOM.findDOMNode.restore()
   })
 })


### PR DESCRIPTION
This adds the ability to register an `onMounted` callback that will be called with the underlying DOM node as an argument.

This can be useful for a number of reasons, but in our case, it's a workaround for issue https://github.com/imgix/react-imgix/issues/41. This way, we can render the image without the alt tag (which won't affect the size calculation), and append the alt attribute after mounting.