### PR TITLE
pull in prop-types from a separate module, fix sinon deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 	"homepage": "https://github.com/imgix/react-imgix#readme",
 	"peerDependencies": {
 		"react": ">=0.14",
-		"react-dom": ">=0.14"
+		"react-dom": ">=0.14",
+		"prop-types": ">=15.5.6"
 	},
 	"dependencies": {
 		"js-base64": "~2.1.9",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 import './array-findindex';
 
 import ReactDOM from 'react-dom';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { deprecate } from 'react-is-deprecated';
 
 import processImage from './support.js';

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -463,7 +463,7 @@ describe('image props', () => {
 
     tree = sd.shallowRender(<Imgix src={'https://mysource.imgix.net/demo.png'} onMounted={onMountedSpy} />);
     instance = tree.getMountedInstance();
-    sinon.stub(ReactDOM, 'findDOMNode', () => mockImage);
+    sinon.stub(ReactDOM, 'findDOMNode').callsFake(() => mockImage);
     instance.componentDidMount();
 
     sinon.assert.calledWith(onMountedSpy, mockImage);


### PR DESCRIPTION
i tested with 15.5. and 15.4 and this change worked fine - i tried to test with 0.14.x but gave up trying to chase down the required `devDependencies` changes. if this is important we might consider setting up multiple builds to verify older version compatibility. 

