### PR TITLE
npm updates / changes for skin-deep-1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,60 +1,60 @@
 {
-	"name": "react-imgix",
-	"version": "5.4.0",
-	"description": "React Component for displaying an image from Imgix",
-	"main": "lib/index.js",
-	"standard": {
-		"parser": "babel-eslint"
-	},
-	"scripts": {
-		"build": "npm run build:lib",
-		"build:lib": "babel src --out-dir lib",
-		"build:watch": "babel src --out-dir lib --watch",
-		"prepublish": "npm run build",
-		"test": "npm run pretty && mocha --require babel-core/register --recursive src/*.test.js",
-		"pretty": "./node_modules/.bin/prettier --single-quote --trailing-comma es5 --print-width 120 --write \"src/**/*.js\"",
-		"test:watch": "mocha --require babel-core/register --recursive src/*.test.js --watch --reporter min"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/imgix/react-imgix.git"
-	},
-	"keywords": [
-		"react"
-	],
-	"author": "Frederick Fogerty",
-	"license": "ISC",
-	"bugs": {
-		"url": "https://github.com/imgix/react-imgix/issues"
-	},
-	"homepage": "https://github.com/imgix/react-imgix#readme",
-	"peerDependencies": {
-		"react": ">=0.14",
-		"react-dom": ">=0.14",
-		"prop-types": ">=15.5.6"
-	},
-	"dependencies": {
-		"js-base64": "~2.1.9",
-		"jsuri": "^1.3.1",
-		"react-is-deprecated": "^0.1.2"
-	},
-	"devDependencies": {
-		"babel-cli": "^6.24.1",
-		"babel-core": "^6.24.1",
-		"babel-eslint": "^7.2.1",
-		"babel-plugin-transform-object-assign": "^6.22.0",
-		"babel-preset-es2015": "^6.24.1",
-		"babel-preset-react": "^6.24.1",
-		"babel-preset-stage-0": "^6.24.1",
-		"expect": "^1.12.2",
-		"expect-jsx": "^3.0.0",
-		"mocha": "^3.2.0",
-		"mocha-babel": "^3.0.0",
-		"prettier": "^0.22.0",
-		"react": "^15.5.1",
-		"react-addons-test-utils": "^15.5.0",
-		"react-dom": "^15.5.1",
-		"sinon": "^2.1.0",
-		"skin-deep": "^1.0.0-alpha2"
-	}
+  "name": "react-imgix",
+  "version": "5.4.0",
+  "description": "React Component for displaying an image from Imgix",
+  "main": "lib/index.js",
+  "standard": {
+    "parser": "babel-eslint"
+  },
+  "scripts": {
+    "build": "npm run build:lib",
+    "build:lib": "babel src --out-dir lib",
+    "build:watch": "babel src --out-dir lib --watch",
+    "prepublish": "npm run build",
+    "test": "npm run pretty && mocha --require babel-core/register --recursive src/*.test.js",
+    "pretty": "./node_modules/.bin/prettier --single-quote --trailing-comma es5 --print-width 120 --write \"src/**/*.js\"",
+    "test:watch": "mocha --require babel-core/register --recursive src/*.test.js --watch --reporter min"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/imgix/react-imgix.git"
+  },
+  "keywords": [
+    "react"
+  ],
+  "author": "Frederick Fogerty",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/imgix/react-imgix/issues"
+  },
+  "homepage": "https://github.com/imgix/react-imgix#readme",
+  "peerDependencies": {
+    "react": ">=0.14",
+    "react-dom": ">=0.14",
+    "prop-types": ">=15.5.6"
+  },
+  "dependencies": {
+    "js-base64": "~2.1.9",
+    "jsuri": "^1.3.1",
+    "react-is-deprecated": "^0.1.2"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.24.1",
+    "babel-eslint": "^7.2.2",
+    "babel-plugin-transform-object-assign": "^6.22.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
+    "expect": "^1.20.2",
+    "expect-jsx": "^3.0.0",
+    "mocha": "^3.2.0",
+    "mocha-babel": "^3.0.3",
+    "prettier": "^0.22.0",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "react-test-renderer": "^15.5.4",
+    "sinon": "^2.1.0",
+    "skin-deep": "^1.0.0"
+  }
 }


### PR DESCRIPTION
fixes the required packages for [skin-deep](https://github.com/glenjamin/skin-deep#install) when using `react 15.5`, updates other `devDependencies`.  should supersede #103 (also fixes react warnings in the build)