### PR TITLE
chore: add es build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
-	"presets": ["react", "env", "stage-0"],
-	"plugins": ["transform-object-assign"]
+	"presets": ["react", ["env", { "modules": false }], "stage-0"],
+	"plugins": ["transform-object-assign"],
+	"env": {
+		"commonjs": {
+			"presets": ["react", "env", "stage-0"]
+		}
+	}
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 npm-debug.log
 
+es
 lib
 node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "@babel/types": "7.0.0-beta.32",
         "babylon": "7.0.0-beta.32",
         "debug": "3.1.0",
-        "globals": "10.3.0",
+        "globals": "10.4.0",
         "invariant": "2.2.2",
         "lodash": "4.17.4"
       },
@@ -118,9 +118,9 @@
           }
         },
         "globals": {
-          "version": "10.3.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-10.3.0.tgz",
-          "integrity": "sha512-1g6qO5vMbiPHbRTDtR9JVjRkAhkgH4nSANYGyx1eOfqgxcMnYMMD+7MjmjfzXjwFpVUE/7/NzF+jQxYE7P4r7A==",
+          "version": "10.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+          "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
           "dev": true
         }
       }
@@ -142,6 +142,16 @@
           "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
         }
+      }
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
       }
     },
     "align-text": {
@@ -1273,7 +1283,7 @@
       "integrity": "sha512-vJEBcDTANoDhSHL46NeOEW5hvQw7It9uCqzeFPQhpawXfnOwnpvW5C97vn1eGJ7iCkSg8wWU0nYObE7d/N95Iw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000765",
+        "caniuse-lite": "1.0.30000766",
         "electron-to-chromium": "1.3.27"
       }
     },
@@ -1300,9 +1310,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000765",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000765.tgz",
-      "integrity": "sha1-qhp1AZJ2tIRjwPyipSV/ufJqfJ0=",
+      "version": "1.0.30000766",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000766.tgz",
+      "integrity": "sha1-iglcxeuZI8JwCM5NDbI+ZaPiiEM=",
       "dev": true
     },
     "center-align": {
@@ -1578,8 +1588,8 @@
       "integrity": "sha1-HxXOa4RPfKQUlcgZDAgzwwuLFpM=",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.1",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.2.0",
@@ -1619,6 +1629,16 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cross-env": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.1.tgz",
+      "integrity": "sha512-Wtvr+z0Z06KO1JxjfRRsPC+df7biIOiuV4iZ73cThjFGkH+ULBZq1MkBdywEcJC4cTDbO6c8IjgRjfswx3YTBA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "is-windows": "1.0.1"
+      }
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -2348,7 +2368,8 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -2681,14 +2702,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2697,6 +2710,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -2766,7 +2787,8 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
@@ -3185,6 +3207,12 @@
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
+    "is-windows": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
+      "dev": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3395,16 +3423,6 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsuri": {
       "version": "1.3.1",
@@ -4315,6 +4333,15 @@
         "align-text": "0.1.4"
       }
     },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -4486,15 +4513,6 @@
         "yargs": "8.0.2"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -4526,6 +4544,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -3,18 +3,23 @@
   "version": "7.0.0",
   "description": "React Component for displaying an image from Imgix",
   "main": "lib/index.js",
-  "standard": {
-    "parser": "babel-eslint"
-  },
+  "module": "es/index.js",
+  "jsnext:main": "es/index.js",
+  "files": [
+    "lib/*",
+    "es/*"
+  ],
   "scripts": {
-    "build": "npm run build:lib",
-    "build:lib": "babel src --out-dir lib",
-    "build:watch": "babel src --out-dir lib --watch",
+    "build": "npm run clean && npm run build:commonjs && npm run build:es",
+    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib --source-maps",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es --source-maps",
+    "build:watch": "cross-env BABEL_ENV=commonjs babel src --out-dir lib --watch",
+    "clean": "rimraf lib es",
     "prepublish": "npm run build",
-    "test": "npm run pretty && mocha --require babel-core/register --recursive src/*.test.js",
-    "pretty": "./node_modules/.bin/prettier --single-quote --trailing-comma es5 --print-width 120 --write \"src/**/*.js\"",
-    "test:watch": "mocha --require babel-core/register --recursive src/*.test.js --watch --reporter min",
-    "release": "standard-version"
+    "pretty": "cross-env BABEL_ENV=commonjs prettier --single-quote --trailing-comma es5 --print-width 120 --write \"src/**/*.js\"",
+    "release": "standard-version",
+    "test:watch": "cross-env BABEL_ENV=commonjs mocha --require babel-core/register --recursive src/*.test.js --watch --reporter min",
+    "test": "npm run pretty && cross-env BABEL_ENV=commonjs mocha --require babel-core/register --recursive src/*.test.js"
   },
   "repository": {
     "type": "git",
@@ -46,6 +51,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
+    "cross-env": "^5.1.1",
     "expect": "^21.2.1",
     "mocha": "^4.0.1",
     "mocha-babel": "^3.0.3",
@@ -53,6 +59,7 @@
     "react": "^16.1.1",
     "react-dom": "^16.1.1",
     "react-test-renderer": "^16.1.1",
+    "rimraf": "^2.6.2",
     "sinon": "^4.1.2",
     "skin-deep": "^1.1.0",
     "standard-version": "^4.2.0"

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -9,7 +9,7 @@ import ReactDOM from 'react-dom';
 import Imgix from './index.js';
 
 const src = 'http://domain.imgix.net/image.jpg';
-let tree, vdom, instance; // eslint-disable-line no-unused-vars
+let tree, vdom, instance;
 
 describe('<img> mode', () => {
   beforeEach(() => {


### PR DESCRIPTION
hah, i was really hoping to get this in before you did the 7 bump (this is why i was upgrading deps, i wanted to make that a separate change though).

the only thing that's not 100% is `build:watch` - i don't know an easy pattern to have multiple watch processes running. not sure how much that matters though, i could add a separate `commonjs` and `es` watch task 