### PR TITLE
feat: add ixlib url parameter to help Imgix support and analytics

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,12 @@
 {
-	"presets": ["react", ["env", { "modules": false }], "stage-0"],
-	"plugins": ["transform-object-assign"],
-	"env": {
-		"commonjs": {
-			"presets": ["react", "env", "stage-0"]
-		},
-		"test": {
-			"presets": ["react", "env", "stage-0"]
-		}
-	}
+  "presets": ["react", ["env", { "modules": false }], "stage-0"],
+  "plugins": ["transform-object-assign", "inline-package-json"],
+  "env": {
+    "commonjs": {
+      "presets": ["react", "env", "stage-0"]
+    },
+    "test": {
+      "presets": ["react", "env", "stage-0"]
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://assets.imgix.net/imgix-logo-web-2014.pdf?page=2&fm=png&w=120" srcset="https://assets.imgix.net/imgix-logo-web-2014.pdf?page=2&fm=png&w=120 1x,
  https://assets.imgix.net/imgix-logo-web-2014.pdf?page=2&fm=png&w=120&dpr=2 2x, https://assets.imgix.net/imgix-logo-web-2014.pdf?page=2&fm=png&w=120&dpr=3 3x" alt="imgix logo">
 
-# Imgix for React
+# imgix for React
 
 [![npm](https://img.shields.io/npm/dm/react-imgix.svg)](https://www.npmjs.com/package/react-imgix)
 [![npm version](https://img.shields.io/npm/v/react-imgix.svg)](https://www.npmjs.com/package/react-imgix)
@@ -10,7 +10,7 @@
 [![Code Climate](https://codeclimate.com/github/imgix/react-imgix/badges/gpa.svg)](https://codeclimate.com/github/imgix/react-imgix)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
-A [React](https://facebook.github.io/react/) component that renders images using the [Imgix](https://www.imgix.com/) API. It uses the smallest images possible, and does cool stuff, like [cropping to faces](https://www.imgix.com/docs/reference/size#param-crop) by default.
+A [React](https://facebook.github.io/react/) component that renders images using the [imgix](https://www.imgix.com/) API. It uses the smallest images possible, and does cool stuff, like [cropping to faces](https://www.imgix.com/docs/reference/size#param-crop) by default.
 
 - [Installation](#installation)
 - [Usage](#usage)
@@ -46,7 +46,7 @@ Whether to wait until the component has mounted to render the image, useful for 
 
 #### auto :: array, default = ['format']
 
-Array of values to pass to Imgix's auto param
+Array of values to pass to imgix's auto param
 
 #### type :: string, default = 'img'
 
@@ -62,7 +62,7 @@ Wrapper component to use when rendering a `bg`, defaults to `div`
 
 #### entropy :: bool, default = false
 
-Whether or not to crop using points of interest. See Imgix API for more details.
+Whether or not to crop using points of interest. See imgix API for more details.
 
 #### faces :: bool, default = true
 
@@ -74,7 +74,7 @@ Sets specific crop, overriding faces and entropy flags. Useful for specifying fa
 
 #### fit :: string
 
-See Imgix's API, defaults to `crop`
+See imgix's API, defaults to `crop`
 
 #### fluid :: bool, default = true
 
@@ -110,11 +110,11 @@ Generate `2x` and `3x` src sets when using an `<img>` tag. Defaults to `true`
 
 #### disableLibraryParam :: bool
 
-By default this component adds a parameter to the generated url to help Imgix with analytics and support for this library. This can be disabled by setting this prop to `true`.
+By default this component adds a parameter to the generated url to help imgix with analytics and support for this library. This can be disabled by setting this prop to `true`.
 
 #### customParams :: object
 
-Any other Imgix params to add to the image `src`
+Any other imgix params to add to the image `src`
 
 _For example_:
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Fallback width for images, useful for SSR or static site generation
 
 Generate `2x` and `3x` src sets when using an `<img>` tag. Defaults to `true`
 
+#### disableLibraryParam :: bool
+
+By default this component adds a parameter to the generated url to help Imgix with analytics and support for this library. This can be disabled by setting this prop to `true`.
+
 #### customParams :: object
 
 Any other Imgix params to add to the image `src`

--- a/package-lock.json
+++ b/package-lock.json
@@ -3088,6 +3088,37 @@
         "read-pkg": "^1.1.0",
         "read-pkg-up": "^1.0.1",
         "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        }
       }
     },
     "conventional-changelog-ember": {
@@ -4658,13 +4689,42 @@
       }
     },
     "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "locate-path": "^3.0.0"
+      },
+      "dependencies": {
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        }
       }
     },
     "flush-write-stream": {
@@ -10736,11 +10796,40 @@
         "trim-newlines": "^1.0.0"
       },
       "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
         }
       }
     },
@@ -11673,6 +11762,12 @@
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
+    "p-try": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+      "dev": true
+    },
     "pac-proxy-agent": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz",
@@ -11822,13 +11917,10 @@
       "dev": true
     },
     "path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "^2.0.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -12529,13 +12621,69 @@
       }
     },
     "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "^3.0.0",
+        "read-pkg": "^3.0.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
       }
     },
     "readable-stream": {
@@ -14973,6 +15121,16 @@
             }
           }
         },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
@@ -15053,6 +15211,25 @@
             "regex-not": "^1.0.0",
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1197,6 +1197,12 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-inline-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-inline-package-json/-/babel-plugin-inline-package-json-2.0.0.tgz",
+      "integrity": "sha1-H5VY2WZn9Lh4foB9dk5uFbTwzQc=",
+      "dev": true
+    },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-core": "^6.25.0",
     "babel-eslint": "^8.0.2",
     "babel-loader": "^7.1.4",
+    "babel-plugin-inline-package-json": "^2.0.0",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "react-addons-test-utils": "^15.6.2",
     "react-dom": "^16.1.1",
     "react-test-renderer": "^16.1.1",
+    "read-pkg-up": "^4.0.0",
     "rimraf": "^2.6.2",
     "sinon": "^4.1.2",
     "skin-deep": "^1.1.0",

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -6,6 +6,8 @@ import PropTypes from "prop-types";
 
 import processImage from "./support.js";
 
+const PACKAGE_VERSION = require("../package.json").version;
+
 const roundToNearest = (size, precision) =>
   precision * Math.ceil(size / precision);
 
@@ -52,7 +54,8 @@ export default class ReactImgix extends Component {
     width: PropTypes.number,
     height: PropTypes.number,
     defaultHeight: PropTypes.number,
-    defaultWidth: PropTypes.number
+    defaultWidth: PropTypes.number,
+    disableLibraryParam: PropTypes.bool
   };
   static defaultProps = {
     aggressiveLoad: false,
@@ -131,7 +134,10 @@ export default class ReactImgix extends Component {
         crop: _crop,
         fit: _fit,
         width,
-        height
+        height,
+        ...(this.props.disableLibraryParam
+          ? {}
+          : { ixlib: `react-${PACKAGE_VERSION}` })
       };
 
       _src = processImage(src, srcOptions);

--- a/test/unit/react-imgix.test.js
+++ b/test/unit/react-imgix.test.js
@@ -604,4 +604,35 @@ describe("When using the component", () => {
 
     ReactDOM.findDOMNode.restore();
   });
+
+  it("an ixlib parameter should be included by default in the computed src", () => {
+    const expectedVersion = require("read-pkg-up").sync().pkg.version;
+
+    sut = shallow(
+      <Imgix src="https://mysource.imgix.net/demo.png" aggressiveLoad />,
+      {
+        disableLifecycleMethods: true
+      }
+    );
+    sut.props();
+    expect(sut.props().src).toContain(`ixlib=react-${expectedVersion}`);
+  });
+  it("an ixlib parameter should be included by default in the computed srcSet", () => {
+    const expectedVersion = require("read-pkg-up").sync().pkg.version;
+    const expectedParam = `ixlib=react-${expectedVersion}`;
+
+    sut = shallow(
+      <Imgix src="https://mysource.imgix.net/demo.png" aggressiveLoad />,
+      {
+        disableLifecycleMethods: true
+      }
+    );
+
+    sut
+      .props()
+      .srcSet.split(",")
+      .forEach(srcSet => {
+        expect(srcSet).toContain(expectedParam);
+      });
+  });
 });

--- a/test/unit/react-imgix.test.js
+++ b/test/unit/react-imgix.test.js
@@ -75,6 +75,13 @@ describe("When in <source> mode", () => {
     it(`props.alt should not be defined`, () => {
       expect(renderImage().props().alt).toBe(undefined);
     });
+
+    it("an ixlib param should be added to the src", () => {
+      renderImage()
+        .props()
+        .srcSet.split(",")
+        .forEach(srcSet => expectUrlToContainIxLibParam(srcSet));
+    });
   };
 
   describe("with the generateSrcSet prop", () => {
@@ -411,12 +418,14 @@ describe("When using the component", () => {
     expect(sut.props().src).toContain("fit=crop");
   });
   it("the keys of custom url parameters should be url encoded", () => {
+    const helloWorldKey = "hello world";
+    const expectedKey = "hello%20world";
     sut = shallow(
       <Imgix
         src={"https://mysource.imgix.net/demo.png"}
         aggressiveLoad
         customParams={{
-          "hello world": "interesting"
+          [helloWorldKey]: "interesting"
         }}
       />,
       {
@@ -424,17 +433,19 @@ describe("When using the component", () => {
       }
     );
 
-    expect(sut.props().src).toEqual(
-      "https://mysource.imgix.net/demo.png?auto=format&dpr=1&hello%20world=interesting&crop=faces&fit=crop&w=1&h=1"
-    );
+    expect(sut.props().src).toContain(`${expectedKey}=interesting`);
+    expect(sut.props().src).not.toContain(`${helloWorldKey}=interesting`);
   });
   it("the values of custom url parameters should be url encoded", () => {
+    const helloWorldValue = '/foo"> <script>alert("hacked")</script><';
+    const expectedValue =
+      "%2Ffoo%22%3E%20%3Cscript%3Ealert(%22hacked%22)%3C%2Fscript%3E%3C";
     sut = shallow(
       <Imgix
         src={"https://mysource.imgix.net/demo.png"}
         aggressiveLoad
         customParams={{
-          hello_world: '/foo"> <script>alert("hacked")</script><'
+          hello_world: helloWorldValue
         }}
       />,
       {
@@ -442,17 +453,18 @@ describe("When using the component", () => {
       }
     );
 
-    expect(sut.props().src).toEqual(
-      "https://mysource.imgix.net/demo.png?auto=format&dpr=1&hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert(%22hacked%22)%3C%2Fscript%3E%3C&crop=faces&fit=crop&w=1&h=1"
-    );
+    expect(sut.props().src).toContain(`hello_world=${expectedValue}`);
+    expect(sut.props().src).not.toContain(`hello_world=${helloWorldValue}`);
   });
   it("the base64 custom parameter values should be base64 encoded", () => {
+    const txt64Value = "I cannøt belîév∑ it wors! 😱";
+    const expectedValue = "SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE";
     sut = shallow(
       <Imgix
         src={"https://mysource.imgix.net/~text"}
         aggressiveLoad
         customParams={{
-          txt64: "I cannøt belîév∑ it wors! 😱"
+          txt64: txt64Value
         }}
       />,
       {
@@ -460,9 +472,8 @@ describe("When using the component", () => {
       }
     );
 
-    expect(sut.props().src).toEqual(
-      "https://mysource.imgix.net/~text?auto=format&dpr=1&txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE&crop=faces&fit=crop&w=1&h=1"
-    );
+    expect(sut.props().src).toContain(`txt64=${expectedValue}`);
+    expect(sut.props().src).not.toContain(`txt64=${txt64Value}`);
   });
   it("the generateSrcSet prop should add dpr=2 and dpr=3 to the srcSet attribute", () => {
     sut = shallow(<Imgix src={src} aggressiveLoad generateSrcSet />, {
@@ -485,9 +496,7 @@ describe("When using the component", () => {
       }
     );
 
-    expect(sut.props().src).toEqual(
-      `https://mysource.imgix.net/demo.png?auto=format&dpr=1&crop=faces&fit=crop&w=1&h=${height}`
-    );
+    expect(sut.props().src).toContain(`h=${height}`);
   });
 
   it("a height prop between 0 and 1 should not be passed as a prop to the child element rendered", () => {
@@ -535,9 +544,7 @@ describe("When using the component", () => {
       }
     );
 
-    expect(sut.props().src).toEqual(
-      `https://mysource.imgix.net/demo.png?auto=format&dpr=1&crop=faces&fit=crop&w=${width}&h=1`
-    );
+    expect(sut.props().src).toContain(`w=${width}`);
   });
 
   it("a width prop between 0 and 1 should not be passed as a prop to the child element rendered", () => {
@@ -606,21 +613,15 @@ describe("When using the component", () => {
   });
 
   it("an ixlib parameter should be included by default in the computed src", () => {
-    const expectedVersion = require("read-pkg-up").sync().pkg.version;
-
     sut = shallow(
       <Imgix src="https://mysource.imgix.net/demo.png" aggressiveLoad />,
       {
         disableLifecycleMethods: true
       }
     );
-    sut.props();
-    expect(sut.props().src).toContain(`ixlib=react-${expectedVersion}`);
+    expectUrlToContainIxLibParam(sut.props().src);
   });
   it("an ixlib parameter should be included by default in the computed srcSet", () => {
-    const expectedVersion = require("read-pkg-up").sync().pkg.version;
-    const expectedParam = `ixlib=react-${expectedVersion}`;
-
     sut = shallow(
       <Imgix src="https://mysource.imgix.net/demo.png" aggressiveLoad />,
       {
@@ -632,7 +633,28 @@ describe("When using the component", () => {
       .props()
       .srcSet.split(",")
       .forEach(srcSet => {
-        expect(srcSet).toContain(expectedParam);
+        expectUrlToContainIxLibParam(srcSet);
       });
   });
+  it("the addition of the ixlib parameter to the url can be disabled", () => {
+    sut = shallow(
+      <Imgix
+        src="https://mysource.imgix.net/demo.png"
+        aggressiveLoad
+        disableLibraryParam
+      />,
+      {
+        disableLifecycleMethods: true
+      }
+    );
+
+    expect(sut.props().src).not.toContain(`ixlib=`);
+  });
 });
+
+const expectUrlToContainIxLibParam = url => {
+  const expectedVersion = require("read-pkg-up").sync().pkg.version;
+  const expectedParam = `ixlib=react-${expectedVersion}`;
+
+  expect(url).toContain(expectedParam);
+};


### PR DESCRIPTION
## Description

This PR adds an `ixlib` parameter to urls generated by this component. The url parameter is in the form `ixlib=react-7.1.1`. There are two reasons to add this parameter: a) it helps Imgix support see what versions of libraries that customers are using, and b) it help Imgix to see how many people overall are using the react library, and the specific versions.

This functionality is enabled by default but can be turned off by passing the prop `disableLibraryParam`.

This closes #142.

### New Feature

- [x] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Update the readme
- [x] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Either review the unit tests in `test/unit/react-imgix.test.js` or set-up a new app and inspect the generated URLs.