### PR TITLE
fix: alt text no longer cause images to render at wrong dimensions

### DIFF
--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -6,6 +6,9 @@ import PropTypes from "prop-types";
 
 import processImage from "./support.js";
 
+// Best way to include an img with an empty src https://stackoverflow.com/a/5775621/515634 and https://stackoverflow.com/a/19126281/515634
+const EMPTY_IMAGE_SRC = "//:0";
+
 const roundToNearest = (size, precision) =>
   precision * Math.ceil(size / precision);
 
@@ -106,7 +109,7 @@ export default class ReactImgix extends Component {
       type,
       ...other
     } = this.props;
-    let _src = null;
+    let _src = EMPTY_IMAGE_SRC;
     let srcSet = null;
     let _component = component;
 
@@ -140,11 +143,14 @@ export default class ReactImgix extends Component {
       srcSet = `${dpr2} 2x, ${dpr3} 3x`;
     }
 
+    let _alt = (this.props.imgProps || {}).alt;
+
     let childProps = {
       ...this.props.imgProps,
       className: this.props.className,
       width: other.width <= 1 ? null : other.width,
-      height: other.height <= 1 ? null : other.height
+      height: other.height <= 1 ? null : other.height,
+      alt: this.state.mounted || aggressiveLoad ? _alt : undefined
     };
 
     switch (type) {


### PR DESCRIPTION
## Description

Previously, if a user wished to add alt text to an image it would cause the image to be displayed at weird dimensions depending on which browser the user was using. This was due to two reasons: a) in some browsers, including alt text meant that empty images would render at dimensions other than `0x0`, and b) in some browsers, that the first render pass of this component (which renders an empty image) would cause an empty, invalid, image to render at dimensions other than `0x0`. 

Rendering at `0x0` is important for this library to work out what the dimensions of the requested image should be. If the empty image renders at `0x0`, this means that the user has not constrained the size of the image, and that a full-res image should be requested. If the empty image renders at anything other than `0x0`, this means that the user has constrained the image in some way, and that we should only request an image for those dimensions. 

This PR fixes these problems in two ways. First, it only adds the alt text after the first render pass (or if in `aggressiveLoad` mode). Before the second render pass, `alt` is empty. Second, the src for an empty image is now `//:0`. Before now, the component rendered an invalid image (as it had no src), which caused browser behaviour to be undefined. Now, with the new src, the image is valid, and browsers render the image consistently. The image is still empty as the src is invalid (0 is not a valid port).

This fixes #41. 

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Update the readme
- [x] Update or add any necessary API documentation
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Review the unit tests in `test/integration/react-imgix.test.js`