### PR TITLE
chore(integration-test): increase mocha timeout to try stop tests failing randomly

### DIFF
--- a/config/karma/karmaConfig.js
+++ b/config/karma/karmaConfig.js
@@ -222,7 +222,12 @@ const fullConfig = karmaConfig => {
         flags: ["-headless"]
       }
     },
-    plugins: [...baseConfig.plugins]
+    plugins: [...baseConfig.plugins],
+    client: {
+      mocha: {
+        timeout: 20000 // 20 seconds
+      }
+    }
   };
 
   if (isBrowserStackAvailable()) {


### PR DESCRIPTION
## Description

Builds were flaking on Travis as some integration tests were randomly timing out. This increases the timeout by 10x from 2s to 20s, which should stop these tests from timing out.