### PR TITLE
chore(integration-test): add ios integration test support

### DIFF
--- a/config/karma/karmaConfig.js
+++ b/config/karma/karmaConfig.js
@@ -19,7 +19,8 @@ const baseConfig = {
   browserConnectTimeout: 3000,
   browserNoActivityTimeout: 15000,
   webpack: webpackConfig,
-  webpackMiddleware: {}
+  webpackMiddleware: {},
+  concurrency: 5
 };
 
 /**
@@ -77,6 +78,27 @@ const localConfig = karmaConfig => {
 /**
  * CI testing - Chrome, Firefox, and (if available) BrowserStack
  */
+
+const headlessConfigCI = karmaConfig => {
+  const config = {
+    ...baseConfig,
+    reporters: [...baseConfig.reporters],
+    browsers: ["ChromeTravis", "FirefoxHeadless"],
+    customLaunchers: {
+      ChromeTravis: {
+        base: "ChromeHeadless",
+        flags: ["--no-sandbox"]
+      },
+      FirefoxHeadless: {
+        base: "Firefox",
+        flags: ["-headless"]
+      }
+    },
+    plugins: [...baseConfig.plugins]
+  };
+
+  karmaConfig.set(config);
+};
 
 const availableOnWindows = browser =>
   ["ie", "edge", "chrome", "firefox"].includes(browser);
@@ -208,57 +230,36 @@ const mapBrowsersListToBrowserStackLaunchers = browserslistList => {
 };
 
 const fullConfig = karmaConfig => {
-  let config = {
+  if (!isBrowserStackAvailable()) {
+    console.log("BrowserStack not available");
+    process.exit(0);
+  }
+
+  const browserslist = require("browserslist");
+  const {
+    browsers: bsBrowsers,
+    customLaunchers: customBSLaunchers
+  } = mapBrowsersListToBrowserStackLaunchers(browserslist());
+  const bsBrowsersWithoutChromeAndFirefox = bsBrowsers.filter(
+    browser => !(browser.includes("chrome") || browser.includes("firefox"))
+  );
+
+  const config = {
     ...baseConfig,
-    reporters: [...baseConfig.reporters],
-    browsers: ["ChromeTravis", "FirefoxHeadless"],
-    customLaunchers: {
-      ChromeTravis: {
-        base: "ChromeHeadless",
-        flags: ["--no-sandbox"]
-      },
-      FirefoxHeadless: {
-        base: "Firefox",
-        flags: ["-headless"]
-      }
-    },
-    plugins: [...baseConfig.plugins]
-  };
 
-  if (isBrowserStackAvailable()) {
-    const browserslist = require("browserslist");
-    const {
-      browsers: bsBrowsers,
-      customLaunchers: customBSLaunchers
-    } = mapBrowsersListToBrowserStackLaunchers(browserslist());
-
-    config.browserStack = {
+    hostname: "bs-local.com",
+    port: 9876,
+    browserStack: {
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_ACCESS_KEY
-    };
+    },
 
-    config.reporters = [...config.reporters, "BrowserStack"];
-
-    const bsBrowsersWithoutChromeAndFirefox = bsBrowsers.filter(
-      browser => !(browser.includes("chrome") || browser.includes("firefox"))
-    );
-    // TODO: Enable iPhone tests when BrowserStack support replies
-    const bsBrowsersWithoutChromeAndFirefoxAndIOS = bsBrowsersWithoutChromeAndFirefox.filter(
-      browser => !browser.includes("iPhone")
-    );
-
-    config.browsers = [
-      ...config.browsers,
-      ...bsBrowsersWithoutChromeAndFirefoxAndIOS
-    ];
-
-    config.customLaunchers = {
-      ...config.customLaunchers,
-      ...customBSLaunchers
-    };
-
-    config.plugins = [...config.plugins, "karma-browserstack-launcher"];
-  }
+    browsers: bsBrowsersWithoutChromeAndFirefox,
+    reporters: [...baseConfig.reporters, "BrowserStack"],
+    customLaunchers: customBSLaunchers,
+    plugins: [...baseConfig.plugins, "karma-browserstack-launcher"],
+    autoWatch: false
+  };
 
   console.log(
     "Testing on browsers:\n",
@@ -285,3 +286,4 @@ function isBrowserStackAvailable() {
 exports.full = fullConfig;
 exports.local = localConfig;
 exports.headless = headlessConfig;
+exports.headlessCI = headlessConfigCI;

--- a/config/karma/karmaConfigHeadlessCI.js
+++ b/config/karma/karmaConfigHeadlessCI.js
@@ -1,0 +1,1 @@
+module.exports = require("./karmaConfig").headlessCI;

--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
     "test:headless": "karma start config/karma/karmaConfigHeadless.js --singleRun",
     "test:headless:watch": "karma start config/karma/karmaConfigHeadless.js",
     "test:browser": "karma start config/karma/karmaConfigLocal.js --singleRun",
-    "test:browser:watch": "karma start config/karma/karmaConfigLocal.js",
-    "test:browser:all": "karma start config/karma/karmaConfigBrowserStack.js --singleRun",
+		"test:browser:watch": "karma start config/karma/karmaConfigLocal.js",
+		"test:browser:ci": "karma start config/karma/karmaConfigHeadlessCI.js --singleRun",
+		"test:browser:browserstack": "karma start config/karma/karmaConfigBrowserStack.js --singleRun",
+    "test:browser:all": "npm run test:browser:ci && npm run test:browser:browserstack",
     "test:watch": "jest --watch",
     "test": "jest && npm run test:browser:all"
   },


### PR DESCRIPTION
## Description

Previously iOS was not able to be tested on BrowserStack due to issues with the interaction with BrowserStack. This has now been fixed so iOS support can be re-enabled.

## Steps to Test

Check that the Travis CI log is testing iOS ("mobile safari")

![image](https://user-images.githubusercontent.com/615334/42245936-d80ce508-7f6e-11e8-9807-ec4fa833cc80.png)

Can be see above as `bs_ios_saf_iPhone 8_11.0`