### PR TITLE
feat: refactor picture and source behaviour into different components

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Any other attributes to add to the html node (example: `alt`, `data-*`, `classNa
 
 ### 7.x to 8.0
 
-This is a very large update to this library with a lot of breaking changes. We apologise for any issues this may cause, and we have tried to reduce the number of breaking changes. We have also worked to batch up all these changes into one release to reduce its impacts. We do not plan on making breaking changes for a while after this, and will be focussed on adding features, such as video support.
+This is a very large update to this library with a lot of breaking changes. We apologise for any issues this may cause, and we have tried to reduce the number of breaking changes. We have also worked to batch up all these changes into one release to reduce its impacts. We do not plan on making breaking changes for a while after this, and will be focussed on adding features.
 
 The largest change in this major version bump is the move to width-based `srcSet` and `sizes` for responsiveness. This has a host of benefits, including better server rendering, better responsiveness, less potential for bugs, perfomance improvements
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,33 @@ import Imgix, { Picture, Source } from 'react-imgix'
 </Picture>
 ```
 
-TODO: Add prop fall-through/default thing support i.e. props on Picture get passed down
+In order to reduce the duplication in props, JSX supports object spread for props:
+
+```js
+import Imgix, { Picture, Source } from 'react-imgix'
+
+const commonProps = {
+	src: 'https://...',
+	imgixParams: {
+		fit: 'crop',
+		crop: 'faces'
+	}
+}
+
+<Picture>
+	<Source
+		{...commonProps}
+    width={400}
+    imgProps={{ media: "(min-width: 768px)" }}
+  />
+  <Source
+    {...commonProps}
+    width={200}
+    imgProps={{ media: "(min-width: 320px)" }}
+  />
+  <Imgix src={src} width={100} />
+</Picture>
+```
 
 #### Background mode
 

--- a/README.md
+++ b/README.md
@@ -177,12 +177,12 @@ import Imgix, { Picture, Source } from 'react-imgix'
   <Source
     src={src}
     width={400}
-    imgProps={{ media: "(min-width: 768px)" }}
+    htmlAttributes={{ media: "(min-width: 768px)" }}
   />
   <Source
     src={src}
     width={200}
-    imgProps={{ media: "(min-width: 320px)" }}
+    htmlAttributes={{ media: "(min-width: 320px)" }}
   />
   <Imgix src={src} width={100} />
 </Picture>
@@ -205,12 +205,12 @@ const commonProps = {
 	<Source
 		{...commonProps}
     width={400}
-    imgProps={{ media: "(min-width: 768px)" }}
+    htmlAttributes={{ media: "(min-width: 768px)" }}
   />
   <Source
     {...commonProps}
     width={200}
-    imgProps={{ media: "(min-width: 320px)" }}
+    htmlAttributes={{ media: "(min-width: 320px)" }}
   />
   <Imgix src={src} width={100} />
 </Picture>
@@ -246,7 +246,7 @@ Specified the developer's expected size of the image element when rendered on th
 
 ##### className :: string
 
-`className` applied to top level component. To set `className` on the image itself see `imgProps`.
+`className` applied to top level component. To set `className` on the image itself see `htmlAttributes`.
 
 ##### height :: number
 
@@ -264,7 +264,7 @@ Disable generation of variable width src sets to enable responsiveness.
 
 By default this component adds a parameter to the generated url to help imgix with analytics and support for this library. This can be disabled by setting this prop to `true`.
 
-##### imgProps :: object
+##### htmlAttributes :: object
 
 Any other attributes to add to the html node (example: `alt`, `data-*`, `className`).
 
@@ -276,13 +276,13 @@ Called on `componentDidMount` with the mounted DOM node as an argument.
 
 ##### className :: string
 
-`className` applied to top level component. To set `className` on the image itself see `imgProps`.
+`className` applied to top level component. To set `className` on the image itself see `htmlAttributes`.
 
 ##### onMounted :: func
 
 Called on `componentDidMount` with the mounted DOM node as an argument.
 
-##### imgProps :: object
+##### htmlAttributes :: object
 
 Any other attributes to add to the html node (example: `alt`, `data-*`, `className`).
 

--- a/README.md
+++ b/README.md
@@ -171,22 +171,24 @@ import Imgix from "react-imgix";
 Using the [<picture> element](https://docs.imgix.com/tutorials/using-imgix-picture-element) you can create responsive images:
 
 ```js
-<Imgix src={src} type="picture">
-  <Imgix
+import Imgix, { Picture, Source } from 'react-imgix'
+
+<Picture>
+  <Source
     src={src}
     width={400}
-    type="source"
     imgProps={{ media: "(min-width: 768px)" }}
   />
-  <Imgix
+  <Source
     src={src}
     width={200}
-    type="source"
     imgProps={{ media: "(min-width: 320px)" }}
   />
-  <Imgix src={src} width={100} type="img" />
-</Imgix>
+  <Imgix src={src} width={100} />
+</Picture>
 ```
+
+TODO: Add prop fall-through/default thing support i.e. props on Picture get passed down
 
 #### Background mode
 
@@ -211,10 +213,6 @@ _For example_:
 #### sizes :: string
 
 Specified the developer's expected size of the image element when rendered on the page. Similar to width. E.g. `100vw`, `calc(50vw - 50px)`, `500px`. Highly recommended when not passing `width` or `height`. [Eric Portis' "Srcset and sizes"](https://ericportis.com/posts/2014/srcset-sizes/) article goes into depth on how to use the `sizes` attribute.
-
-#### type :: string, default = 'img'
-
-What kind of component to render, one of `img`, picture`,`source`.
 
 #### className :: string
 

--- a/README.md
+++ b/README.md
@@ -222,11 +222,15 @@ This feature has been removed from react-imgix when `sizes` and `srcset` was imp
 
 ### Props
 
-#### src :: string, required
+#### Shared Props (Imgix, Source)
+
+These props are shared among Imgix and Source Components
+
+##### src :: string, required
 
 Usually in the form: `https://[your_domain].imgix.net/[image]`. Don't include any parameters.
 
-#### imgixParams :: object
+##### imgixParams :: object
 
 Imgix params to add to the image `src`.
 
@@ -236,37 +240,51 @@ _For example_:
 <Imgix imgixParams={{ mask: "ellipse" }} />
 ```
 
-#### sizes :: string
+##### sizes :: string
 
 Specified the developer's expected size of the image element when rendered on the page. Similar to width. E.g. `100vw`, `calc(50vw - 50px)`, `500px`. Highly recommended when not passing `width` or `height`. [Eric Portis' "Srcset and sizes"](https://ericportis.com/posts/2014/srcset-sizes/) article goes into depth on how to use the `sizes` attribute.
 
-#### className :: string
+##### className :: string
 
 `className` applied to top level component. To set `className` on the image itself see `imgProps`.
 
-#### height :: number
+##### height :: number
 
 Force images to be a certain height.
 
-#### width :: number
+##### width :: number
 
 Force images to be a certain width.
 
-#### disableSrcSet :: bool, default = false
+##### disableSrcSet :: bool, default = false
 
 Disable generation of variable width src sets to enable responsiveness.
 
-#### disableLibraryParam :: bool
+##### disableLibraryParam :: bool
 
 By default this component adds a parameter to the generated url to help imgix with analytics and support for this library. This can be disabled by setting this prop to `true`.
 
-#### imgProps :: object
+##### imgProps :: object
 
 Any other attributes to add to the html node (example: `alt`, `data-*`, `className`).
 
-#### onMounted :: func
+##### onMounted :: func
 
 Called on `componentDidMount` with the mounted DOM node as an argument.
+
+#### Picture Props
+
+##### className :: string
+
+`className` applied to top level component. To set `className` on the image itself see `imgProps`.
+
+##### onMounted :: func
+
+Called on `componentDidMount` with the mounted DOM node as an argument.
+
+##### imgProps :: object
+
+Any other attributes to add to the html node (example: `alt`, `data-*`, `className`).
 
 ## Upgrade Guides
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,22 @@ The largest change in this major version bump is the move to width-based `srcSet
 To upgrade to version 8, the following changes should be made.
 
 - A `sizes` prop should be added to all usages of Imgix. If `sizes` is new to you (or even if it's not), Eric's [seminal article on `srcset` and `sizes`](https://ericportis.com/posts/2014/srcset-sizes/) is highly recommended.
+- Change all usages of `type='picture'` to `<Picture>` and `type='source'` to `<Source>`
+
+      // this...
+      <Imgix type='picture'>
+      	<Imgix type='source' src={src}>
+      	<Imgix type='source' src={src}>
+      </Imgix>
+
+      // becomes...
+      <Picture>
+      	<Source src={src}>
+      	<Source src={src}>
+      </Picture>
+
+  See [Picture support](#picture-support) for more information.
+
 - Remove all usage of `type='bg'` as it is no longer supported. It was decided that it was too hard to implement this feature consistently. If you would still like to use this feature, please give this issue a thumbs up: [https://github.com/imgix/react-imgix/issues/160].(https://github.com/imgix/react-imgix/issues/160) If we get enough requests for this, we will re-implement it.
 - Remove props `aggressiveLoad`, `component`, `fluid`, `precision` as they are no longer used.
 - Change all usages of `defaultHeight` and `defaultWidth` to `width` and `height` props.

--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ Any other attributes to add to the html node (example: `alt`, `data-*`, `classNa
 
 ### 7.x to 8.0
 
+This is a very large update to this library with a lot of breaking changes. We apologise for any issues this may cause, and we have tried to reduce the number of breaking changes. We have also worked to batch up all these changes into one release to reduce its impacts. We do not plan on making breaking changes for a while after this, and will be focussed on adding features, such as video support.
+
 The largest change in this major version bump is the move to width-based `srcSet` and `sizes` for responsiveness. This has a host of benefits, including better server rendering, better responsiveness, less potential for bugs, perfomance improvements
 
 To upgrade to version 8, the following changes should be made.

--- a/src/HOCs/deprecatePropsHOC.js
+++ b/src/HOCs/deprecatePropsHOC.js
@@ -1,0 +1,76 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+import { warning } from "../common";
+
+const DEPRECATED_PROPS = ["auto", "crop", "fit"];
+const deprecatePropsHOC = WrappedComponent => {
+  const WithDeprecatedProps = props => {
+    const imgixParams = {
+      ...(props.customParams || {}),
+      ...props.imgixParams
+    };
+    const propsWithOutDeprecated = {
+      ...props,
+      imgixParams
+    };
+    DEPRECATED_PROPS.forEach(deprecatedProp => {
+      warning(
+        !(deprecatedProp in props),
+        `The prop '${deprecatedProp}' has been deprecated and will be removed in v9. Please update the usage to <Imgix imgixParams={{${deprecatedProp}: value}} />`
+      );
+
+      if (deprecatedProp in props) {
+        delete propsWithOutDeprecated[deprecatedProp];
+        imgixParams[deprecatedProp] = props[deprecatedProp];
+      }
+    });
+    warning(
+      !("customParams" in props),
+      `The prop 'customParams' has been replaced with 'imgixParams' and will be removed in v9. Please update usage to <Imgix imgixParams={customParams} />`
+    );
+    delete propsWithOutDeprecated.customParams;
+
+    if (props.faces) {
+      warning(
+        false,
+        `The prop 'faces' has been deprecated and will be removed in v9. Please update the usage to <Imgix imgixParams={{crop: 'faces'}} />`
+      );
+      delete propsWithOutDeprecated.faces;
+      if (!imgixParams.crop) {
+        imgixParams.crop = "faces";
+      }
+    }
+    if (props.entropy) {
+      warning(
+        false,
+        `The prop 'entropy' has been deprecated and will be removed in v9. Please update the usage to <Imgix imgixParams={{crop: 'entropy'}} />`
+      );
+      delete propsWithOutDeprecated.entropy;
+      if (!imgixParams.crop) {
+        imgixParams.crop = "entropy";
+      }
+    }
+
+    return <WrappedComponent {...propsWithOutDeprecated} />;
+  };
+  WithDeprecatedProps.propTypes = {
+    ...WrappedComponent.propTypes,
+    auto: PropTypes.array,
+    customParams: PropTypes.object,
+    crop: PropTypes.string,
+    entropy: PropTypes.bool,
+    faces: PropTypes.bool,
+    fit: PropTypes.string
+  };
+  WithDeprecatedProps.defaultProps = {
+    imgixParams: {}
+  };
+  WithDeprecatedProps.displayName = `WithDeprecatedProps(${
+    WrappedComponent.displayName
+  })`;
+
+  return WithDeprecatedProps;
+};
+
+export { deprecatePropsHOC };

--- a/src/HOCs/index.js
+++ b/src/HOCs/index.js
@@ -1,0 +1,2 @@
+export * from "./deprecatePropsHOC";
+export * from "./shouldComponentUpdateHOC";

--- a/src/HOCs/shouldComponentUpdateHOC.js
+++ b/src/HOCs/shouldComponentUpdateHOC.js
@@ -1,0 +1,44 @@
+import React, { Component } from "react";
+
+import { warning, shallowEqual } from "../common";
+
+const ShouldComponentUpdateHOC = WrappedComponent => {
+  class ShouldComponentUpdateHOC extends Component {
+    shouldComponentUpdate = nextProps => {
+      const props = this.props;
+      warning(
+        nextProps.onMounted == this.props.onMounted,
+        "props.onMounted() is changing between renders. This is probably not intended. Ensure that a class method is being passed to Imgix rather than a function that is created every render. If this is intended, ignore this warning."
+      );
+
+      const customizer = (oldProp, newProp, key) => {
+        if (key === "children") {
+          return shallowEqual(oldProp, newProp);
+        }
+        if (key === "imgixParams") {
+          return shallowEqual(oldProp, newProp, (a, b) => {
+            if (Array.isArray(a)) {
+              return shallowEqual(a, b);
+            }
+            return undefined;
+          });
+        }
+        if (key === "htmlAttributes") {
+          return shallowEqual(oldProp, newProp);
+        }
+        return undefined; // handled by shallowEqual
+      };
+      const propsAreEqual = shallowEqual(props, nextProps, customizer);
+      return !propsAreEqual;
+    };
+    render() {
+      return <WrappedComponent {...this.props} />;
+    }
+  }
+  ShouldComponentUpdateHOC.displayName = `ShouldComponentUpdateHOC(${
+    WrappedComponent.displayName
+  })`;
+  return ShouldComponentUpdateHOC;
+};
+
+export { ShouldComponentUpdateHOC };

--- a/src/common.js
+++ b/src/common.js
@@ -2,7 +2,7 @@ export { default as CONSTANTS } from "./constants";
 export { default as warning } from "warning";
 export { default as shallowEqual } from "shallowequal";
 
-// Taken from https://github.com/reduxjs/redux/blob/master/src/compose.js
+// Taken from https://github.com/reduxjs/redux/blob/v4.0.0/src/compose.js
 export function compose(...funcs) {
   if (funcs.length === 0) {
     return arg => arg;

--- a/src/common.js
+++ b/src/common.js
@@ -1,3 +1,16 @@
 export { default as CONSTANTS } from "./constants";
 export { default as warning } from "warning";
 export { default as shallowEqual } from "shallowequal";
+
+// Taken from https://github.com/reduxjs/redux/blob/master/src/compose.js
+export function compose(...funcs) {
+  if (funcs.length === 0) {
+    return arg => arg;
+  }
+
+  if (funcs.length === 1) {
+    return funcs[0];
+  }
+
+  return funcs.reduce((a, b) => (...args) => a(b(...args)));
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
-import ReactImgix from "./react-imgix";
+import ReactImgix, { Picture, Source } from "./react-imgix";
 
 export default ReactImgix;
+export { Picture, Source };

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -46,6 +46,7 @@ const ShouldComponentUpdateHOC = WrappedComponent => {
             return undefined;
           });
         }
+        // TODO: change imgProps to htmlAttributes
         if (key === "imgProps") {
           return shallowEqual(oldProp, newProp);
         }

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 
 import targetWidths from "./targetWidths";
 import constructUrl from "./constructUrl";
-import { deprecatePropsHOC, ShouldComponentUpdateHOC } from "./hocs";
+import { deprecatePropsHOC, ShouldComponentUpdateHOC } from "./HOCs";
 
 import { warning, shallowEqual, compose } from "./common";
 

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -279,7 +279,6 @@ class SourceImpl extends Component {
       width: width <= 1 ? null : width,
       height: height <= 1 ? null : height
     };
-    delete childProps.alt;
 
     // inside of a <picture> element a <source> element ignores its src
     // attribute in favor of srcSet so we set that with either an actual

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -226,7 +226,7 @@ class PictureImpl extends Component {
       ) || [];
 
     // look for an <img> or <ReactImgix type='img'> - at the bare minimum we
-    // have to have a single <img> element or else ie will not work.
+    // have to have a single <img> element or else it will not work.
     let imgIdx = _children.findIndex(
       c =>
         c.type === "img" ||

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -303,6 +303,14 @@ class PictureImpl extends Component {
     ...COMMON_PROP_TYPES,
     children: PropTypes.any
   };
+  static defaultProps = {
+    onMounted: noop
+  };
+
+  componentDidMount = () => {
+    const node = ReactDOM.findDOMNode(this);
+    this.props.onMounted(node);
+  };
   render() {
     const { children } = this.props;
     // TODO: remove?
@@ -353,6 +361,15 @@ class SourceImpl extends Component {
   static propTypes = {
     ...SHARED_IMGIX_AND_SOURCE_PROP_TYPES
     // TODO: add media?
+  };
+  static defaultProps = {
+    disableSrcSet: false,
+    onMounted: noop
+  };
+
+  componentDidMount = () => {
+    const node = ReactDOM.findDOMNode(this);
+    this.props.onMounted(node);
   };
   render() {
     const { children, disableSrcSet, type, width, height } = this.props;

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -206,15 +206,6 @@ class PictureImpl extends Component {
   };
   render() {
     const { children } = this.props;
-    // TODO: remove?
-    // strip out the "alt" tag from childProps since it's not allowed
-    // delete childProps.alt;
-
-    //
-    // we need to make sure an img is the last child so we look for one
-    //    in children
-    //    a. if we find one, move it to the last entry if it's not already there
-    //    b. if we don't find one, warn the user as they probably want to pass one.
 
     // make sure all of our children have key set, otherwise we get react warnings
     let _children =
@@ -225,8 +216,13 @@ class PictureImpl extends Component {
         })
       ) || [];
 
-    // look for an <img> or <ReactImgix type='img'> - at the bare minimum we
-    // have to have a single <img> element or else it will not work.
+    /*
+		We need to make sure an <img /> or <Imgix /> is the last child so we look for one in children
+		  a. if we find one, move it to the last entry if it's not already there
+		  b. if we don't find one, warn the user as they probably want to pass one.
+		*/
+
+    // look for an <img> or <ReactImgix type='img'> - at the bare minimum we have to have a single <img> element or else it will not work.
     let imgIdx = _children.findIndex(
       c =>
         c.type === "img" ||

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -25,6 +25,24 @@ const defaultImgixParams = {
 
 const noop = () => {};
 
+const COMMON_PROP_TYPES = {
+  className: PropTypes.string,
+  // TODO: onMounted for picture
+  onMounted: PropTypes.func,
+  imgProps: PropTypes.object
+};
+
+const SHARED_IMGIX_AND_SOURCE_PROP_TYPES = {
+  ...COMMON_PROP_TYPES,
+  disableSrcSet: PropTypes.bool,
+  disableLibraryParam: PropTypes.bool,
+  imgixParams: PropTypes.object,
+  sizes: PropTypes.string,
+  width: PropTypes.number,
+  height: PropTypes.number,
+  src: PropTypes.string.isRequired
+};
+
 const ShouldComponentUpdateHOC = WrappedComponent => {
   class ShouldComponentUpdateHOC extends Component {
     shouldComponentUpdate = nextProps => {
@@ -128,21 +146,9 @@ function imgixParams(props) {
   };
 }
 
-const COMMON_PROP_TYPES = {
-  className: PropTypes.string,
-  disableSrcSet: PropTypes.bool,
-  onMounted: PropTypes.func,
-  sizes: PropTypes.string,
-  width: PropTypes.number,
-  height: PropTypes.number,
-  disableLibraryParam: PropTypes.bool,
-  imgixParams: PropTypes.object
-};
-
 class ReactImgix extends Component {
   static propTypes = {
-    ...COMMON_PROP_TYPES,
-    src: PropTypes.string.isRequired
+    ...SHARED_IMGIX_AND_SOURCE_PROP_TYPES
   };
   static defaultProps = {
     disableSrcSet: false,
@@ -345,8 +351,7 @@ const Picture = compose(ShouldComponentUpdateHOC)(PictureImpl);
 
 class SourceImpl extends Component {
   static propTypes = {
-    ...COMMON_PROP_TYPES,
-    src: PropTypes.string.isRequired
+    ...SHARED_IMGIX_AND_SOURCE_PROP_TYPES
     // TODO: add media?
   };
   render() {

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -236,7 +236,7 @@ class PictureImpl extends Component {
 
     if (imgIdx === -1) {
       console.warn(
-        "No fallback <img /> found in the children of a <picture> component. A fallback image should be passed to ensure the image renders correctly at all dimensions."
+        "No fallback <img /> or <Imgix /> found in the children of a <picture> component. A fallback image should be passed to ensure the image renders correctly at all dimensions."
       );
     } else if (imgIdx !== _children.length - 1) {
       // found one, need to move it to the end

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -240,7 +240,7 @@ class PictureImpl extends Component {
       );
     } else if (imgIdx !== _children.length - 1) {
       // found one, need to move it to the end
-      _children.splice(_children.length - 1, 0, _children.splice(imgIdx, 1)[0]);
+      _children.push(_children.splice(imgIdx, 1)[0]);
     }
 
     return <picture children={_children} />;
@@ -266,7 +266,7 @@ class SourceImpl extends Component {
     this.props.onMounted(node);
   };
   render() {
-    const { children, disableSrcSet, type, width, height } = this.props;
+    const { disableSrcSet, width, height } = this.props;
 
     const htmlAttributes = this.props.htmlAttributes || {};
 

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -159,7 +159,6 @@ class ReactImgix extends Component {
       className: this.props.className,
       width: width <= 1 ? null : width,
       height: height <= 1 ? null : height,
-      alt: htmlAttributes.alt,
       src
     };
     if (!disableSrcSet) {

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -236,7 +236,7 @@ class PictureImpl extends Component {
 
     if (imgIdx === -1) {
       console.warn(
-        "No fallback image found in the children of a <picture> component. A fallback image should be passed to ensure the image renders correctly at all dimensions."
+        "No fallback <img /> found in the children of a <picture> component. A fallback image should be passed to ensure the image renders correctly at all dimensions."
       );
     } else if (imgIdx !== _children.length - 1) {
       // found one, need to move it to the end

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -188,11 +188,6 @@ class ReactImgix extends Component {
 }
 ReactImgix.displayName = "ReactImgix";
 
-const ReactImgixWrapped = compose(
-  deprecatePropsHOC,
-  ShouldComponentUpdateHOC
-)(ReactImgix);
-
 /**
  * React component used to render <picture> elements with Imgix
  */
@@ -253,8 +248,6 @@ class PictureImpl extends Component {
 }
 PictureImpl.displayName = "ReactImgixPicture";
 
-const Picture = compose(ShouldComponentUpdateHOC)(PictureImpl);
-
 /**
  * React component used to render <source> elements with Imgix
  */
@@ -310,6 +303,11 @@ class SourceImpl extends Component {
 }
 SourceImpl.displayName = "ReactImgixSource";
 
+const ReactImgixWrapped = compose(
+  deprecatePropsHOC,
+  ShouldComponentUpdateHOC
+)(ReactImgix);
+const Picture = compose(ShouldComponentUpdateHOC)(PictureImpl);
 const Source = compose(ShouldComponentUpdateHOC)(SourceImpl);
 
 export default ReactImgixWrapped;

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -29,7 +29,7 @@ const COMMON_PROP_TYPES = {
   className: PropTypes.string,
   // TODO: onMounted for picture
   onMounted: PropTypes.func,
-  imgProps: PropTypes.object
+  htmlAttributes: PropTypes.object
 };
 
 const SHARED_IMGIX_AND_SOURCE_PROP_TYPES = {
@@ -64,8 +64,7 @@ const ShouldComponentUpdateHOC = WrappedComponent => {
             return undefined;
           });
         }
-        // TODO: change imgProps to htmlAttributes
-        if (key === "imgProps") {
+        if (key === "htmlAttributes") {
           return shallowEqual(oldProp, newProp);
         }
         return undefined; // handled by shallowEqual
@@ -177,7 +176,7 @@ class ReactImgix extends Component {
       }
     }
 
-    const imgProps = this.props.imgProps || {};
+    const htmlAttributes = this.props.htmlAttributes || {};
 
     const { src, srcSet } = buildSrc({
       ...this.props,
@@ -186,12 +185,12 @@ class ReactImgix extends Component {
     });
 
     let childProps = {
-      ...this.props.imgProps,
+      ...this.props.htmlAttributes,
       sizes: this.props.sizes,
       className: this.props.className,
       width: width <= 1 ? null : width,
       height: height <= 1 ? null : height,
-      alt: imgProps.alt,
+      alt: htmlAttributes.alt,
       src
     };
     if (!disableSrcSet) {
@@ -374,7 +373,7 @@ class SourceImpl extends Component {
   render() {
     const { children, disableSrcSet, type, width, height } = this.props;
 
-    const imgProps = this.props.imgProps || {};
+    const htmlAttributes = this.props.htmlAttributes || {};
 
     const { src, srcSet } = buildSrc({
       ...this.props,
@@ -383,7 +382,7 @@ class SourceImpl extends Component {
     });
 
     let childProps = {
-      ...this.props.imgProps,
+      ...this.props.htmlAttributes,
       sizes: this.props.sizes,
       className: this.props.className,
       width: width <= 1 ? null : width,
@@ -399,7 +398,7 @@ class SourceImpl extends Component {
     } else {
       childProps.srcSet = `${src}, ${srcSet}`;
     }
-    // for now we'll take media from imgProps which isn't ideal because
+    // for now we'll take media from htmlAttributes which isn't ideal because
     //   a) this isn't an <img>
     //   b) passing objects as props means that react will always rerender
     //      since objects dont respond correctly to ===

--- a/test/integration/react-imgix.test.js
+++ b/test/integration/react-imgix.test.js
@@ -23,8 +23,8 @@ const renderAndWaitForImageLoad = async element => {
     let renderedEl;
     const elementWithOnMounted = React.cloneElement(element, {
       onMounted: () => {},
-      imgProps: {
-        ...(element.props.imgProps || {}),
+      htmlAttributes: {
+        ...(element.props.htmlAttributes || {}),
         onLoad: () => {
           setImmediate(() => resolve(renderedEl));
         }
@@ -54,7 +54,7 @@ describe("When in default mode", () => {
       <Imgix
         src={`${src}`}
         sizes="532px"
-        imgProps={{
+        htmlAttributes={{
           alt: "This is alt text"
         }}
       />

--- a/test/unit/helpers/shallowUntilTarget.test.js
+++ b/test/unit/helpers/shallowUntilTarget.test.js
@@ -9,19 +9,7 @@
 import { shallow } from "enzyme";
 import React, { Component } from "react";
 import sinon from "sinon";
-
-// Taken from https://github.com/reduxjs/redux/blob/master/src/compose.js
-export default function compose(...funcs) {
-  if (funcs.length === 0) {
-    return arg => arg;
-  }
-
-  if (funcs.length === 1) {
-    return funcs[0];
-  }
-
-  return funcs.reduce((a, b) => (...args) => a(b(...args)));
-}
+import { compose } from "../../../src/common";
 
 import { shallowUntilTarget } from "../../helpers";
 

--- a/test/unit/react-imgix.test.js
+++ b/test/unit/react-imgix.test.js
@@ -170,7 +170,12 @@ describe("When in <source> mode", () => {
   describe("with disableSrcSet prop", () => {
     const renderImage = () =>
       shallowSource(
-        <Source src={src} disableSrcSet htmlAttributes={htmlAttributes} sizes={sizes} />
+        <Source
+          src={src}
+          disableSrcSet
+          htmlAttributes={htmlAttributes}
+          sizes={sizes}
+        />
       );
 
     shouldBehaveLikeSource(renderImage);

--- a/test/unit/react-imgix.test.js
+++ b/test/unit/react-imgix.test.js
@@ -250,7 +250,7 @@ describe("When in picture mode", () => {
     );
 
     expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining("No fallback image found")
+      expect.stringContaining("No fallback <img /> or <Imgix /> found")
     );
 
     global.console = oldConsole;

--- a/test/unit/react-imgix.test.js
+++ b/test/unit/react-imgix.test.js
@@ -107,7 +107,7 @@ describe("When in <source> mode", () => {
   const shallowSource = element => shallow(element, __SourceImpl);
   const sizes =
     "(max-width: 30em) 100vw, (max-width: 50em) 50vw, calc(33vw - 100px)";
-  const imgProps = {
+  const htmlAttributes = {
     media: "(min-width: 1200px)",
     type: "image/webp",
     alt: "alt text"
@@ -124,11 +124,11 @@ describe("When in <source> mode", () => {
     it("props.sizes should be defined and equal to the image's props", () =>
       expect(renderImage().props().sizes).toEqual(sizes));
 
-    Object.keys(imgProps)
+    Object.keys(htmlAttributes)
       .filter(k => k !== "alt")
       .forEach(k => {
         it(`props.${k} should be defined and equal to the image's props`, () => {
-          expect(renderImage().props()[k]).toBe(imgProps[k]);
+          expect(renderImage().props()[k]).toBe(htmlAttributes[k]);
         });
       });
     it(`props.alt should not be defined`, () => {
@@ -146,7 +146,7 @@ describe("When in <source> mode", () => {
   describe("by default", () => {
     const renderImage = () => {
       return shallowSource(
-        <Source src={src} imgProps={imgProps} sizes={sizes} />
+        <Source src={src} htmlAttributes={htmlAttributes} sizes={sizes} />
       );
     };
 
@@ -170,7 +170,7 @@ describe("When in <source> mode", () => {
   describe("with disableSrcSet prop", () => {
     const renderImage = () =>
       shallowSource(
-        <Source src={src} disableSrcSet imgProps={imgProps} sizes={sizes} />
+        <Source src={src} disableSrcSet htmlAttributes={htmlAttributes} sizes={sizes} />
       );
 
     shouldBehaveLikeSource(renderImage);
@@ -258,9 +258,9 @@ describe("When in picture mode", () => {
           src={src}
           agressiveLoad
           imgixParams={{ crop: "faces" }}
-          imgProps={{ alt: parentAlt }}
+          htmlAttributes={{ alt: parentAlt }}
         >
-          <Imgix src={src} imgProps={{ alt: childAlt }} />
+          <Imgix src={src} htmlAttributes={{ alt: childAlt }} />
         </Picture>
       );
       children = sut.children();
@@ -281,7 +281,7 @@ describe("When in picture mode", () => {
         imgixParams: {
           crop: "faces"
         },
-        imgProps: {
+        htmlAttributes: {
           alt: childAlt
         }
       });
@@ -294,7 +294,7 @@ describe("When in picture mode", () => {
         <Picture
           src={src}
           imgixParams={{ crop: "faces" }}
-          imgProps={{ alt: parentAlt }}
+          htmlAttributes={{ alt: parentAlt }}
         >
           <img src={src} alt={childAlt} />
         </Picture>
@@ -472,33 +472,33 @@ describe("When using the component", () => {
     expect(sut.props().width).toEqual(width);
   });
 
-  it("an alt attribute should be set given imgProps.alt", async () => {
-    const imgProps = {
+  it("an alt attribute should be set given htmlAttributes.alt", async () => {
+    const htmlAttributes = {
       alt: "Example alt attribute"
     };
     sut = shallow(
       <Imgix
         src={"https://mysource.imgix.net/demo.png"}
         sizes="100vw"
-        imgProps={imgProps}
+        htmlAttributes={htmlAttributes}
       />
     );
-    expect(sut.props().alt).toEqual(imgProps.alt);
+    expect(sut.props().alt).toEqual(htmlAttributes.alt);
   });
 
-  it("any attributes passed via imgProps should be added to the rendered element", () => {
-    const imgProps = {
+  it("any attributes passed via htmlAttributes should be added to the rendered element", () => {
+    const htmlAttributes = {
       "data-src": "https://mysource.imgix.net/demo.png"
     };
     sut = shallow(
       <Imgix
         src={"https://mysource.imgix.net/demo.png"}
         sizes="100vw"
-        imgProps={imgProps}
+        htmlAttributes={htmlAttributes}
       />
     );
 
-    expect(sut.props()["data-src"]).toEqual(imgProps["data-src"]);
+    expect(sut.props()["data-src"]).toEqual(htmlAttributes["data-src"]);
   });
 
   it("an ixlib parameter should be included by default in the computed src and srcSet", () => {

--- a/test/unit/react-imgix.test.js
+++ b/test/unit/react-imgix.test.js
@@ -81,7 +81,27 @@ describe("When in default mode", () => {
   });
 });
 
-describe("When in image mode", () => {});
+describe("When in image mode", () => {
+  it("a callback passed through the onMounted prop should be called", () => {
+    const mockImage = <img />;
+    sinon.stub(ReactDOM, "findDOMNode").callsFake(() => mockImage);
+
+    const onMountedSpy = sinon.spy();
+    sut = shallow(
+      <Imgix
+        src={"https://mysource.imgix.net/demo.png"}
+        sizes="100vw"
+        onMounted={onMountedSpy}
+      />,
+      __ReactImgixImpl,
+      {}
+    );
+
+    sinon.assert.calledWith(onMountedSpy, mockImage);
+
+    ReactDOM.findDOMNode.restore();
+  });
+});
 
 describe("When in <source> mode", () => {
   const shallowSource = element => shallow(element, __SourceImpl);
@@ -157,6 +177,25 @@ describe("When in <source> mode", () => {
     it("props.srcSet should include the specified src passed as props", () => {
       expect(renderImage().props().srcSet).toMatch(new RegExp(`^${src}`));
     });
+  });
+  it("a callback passed through the onMounted prop should be called", () => {
+    const mockImage = <source />;
+    sinon.stub(ReactDOM, "findDOMNode").callsFake(() => mockImage);
+
+    const onMountedSpy = sinon.spy();
+    sut = shallow(
+      <Source
+        src={"https://mysource.imgix.net/demo.png"}
+        sizes="100vw"
+        onMounted={onMountedSpy}
+      />,
+      __SourceImpl,
+      {}
+    );
+
+    sinon.assert.calledWith(onMountedSpy, mockImage);
+
+    ReactDOM.findDOMNode.restore();
   });
 });
 
@@ -274,6 +313,24 @@ describe("When in picture mode", () => {
         alt: childAlt
       });
     });
+  });
+
+  it("a callback passed through the onMounted prop should be called", () => {
+    const mockImage = <source />;
+    sinon.stub(ReactDOM, "findDOMNode").callsFake(() => mockImage);
+
+    const onMountedSpy = sinon.spy();
+    sut = shallow(
+      <Picture onMounted={onMountedSpy}>
+        <img />
+      </Picture>,
+      __PictureImpl,
+      {}
+    );
+
+    sinon.assert.calledWith(onMountedSpy, mockImage);
+
+    ReactDOM.findDOMNode.restore();
   });
 });
 
@@ -442,26 +499,6 @@ describe("When using the component", () => {
     );
 
     expect(sut.props()["data-src"]).toEqual(imgProps["data-src"]);
-  });
-
-  it("a callback passed through the onMounted prop should be called", () => {
-    const mockImage = <img />;
-    sinon.stub(ReactDOM, "findDOMNode").callsFake(() => mockImage);
-
-    const onMountedSpy = sinon.spy();
-    sut = shallow(
-      <Imgix
-        src={"https://mysource.imgix.net/demo.png"}
-        sizes="100vw"
-        onMounted={onMountedSpy}
-      />,
-      __ReactImgixImpl,
-      {}
-    );
-
-    sinon.assert.calledWith(onMountedSpy, mockImage);
-
-    ReactDOM.findDOMNode.restore();
   });
 
   it("an ixlib parameter should be included by default in the computed src and srcSet", () => {

--- a/test/unit/react-imgix.test.js
+++ b/test/unit/react-imgix.test.js
@@ -109,8 +109,7 @@ describe("When in <source> mode", () => {
     "(max-width: 30em) 100vw, (max-width: 50em) 50vw, calc(33vw - 100px)";
   const htmlAttributes = {
     media: "(min-width: 1200px)",
-    type: "image/webp",
-    alt: "alt text"
+    type: "image/webp"
   };
   const shouldBehaveLikeSource = function(renderImage) {
     it("a <source> component should be rendered", () => {
@@ -131,10 +130,6 @@ describe("When in <source> mode", () => {
           expect(renderImage().props()[k]).toBe(htmlAttributes[k]);
         });
       });
-    it(`props.alt should not be defined`, () => {
-      expect(renderImage().props().alt).toBe(undefined);
-    });
-
     it("an ixlib param should be added to the src", () => {
       renderImage()
         .props()

--- a/test/unit/react-imgix.test.js
+++ b/test/unit/react-imgix.test.js
@@ -5,7 +5,7 @@ import { shallow as enzymeShallow, mount } from "enzyme";
 import PropTypes from "prop-types";
 import { shallowUntilTarget } from "../helpers";
 
-import Imgix, { __ReactImgix } from "react-imgix";
+import Imgix, { __ReactImgix, Picture, Source } from "react-imgix";
 
 function shallow(element, shallowOptions) {
   return shallowUntilTarget(element, __ReactImgix, {
@@ -43,13 +43,13 @@ async function renderImageAndBreakInStages({
 }
 
 let oldConsole, log;
-beforeAll(() => {
+beforeEach(() => {
   oldConsole = global.console;
   delete console.log;
   console.error = console.log;
   log = console.log.bind(console);
 });
-afterAll(() => {
+afterEach(() => {
   global.console = oldConsole;
 });
 
@@ -118,9 +118,7 @@ describe("When in <source> mode", () => {
 
   describe("by default", () => {
     const renderImage = () =>
-      shallow(
-        <Imgix src={src} type="source" imgProps={imgProps} sizes={sizes} />
-      );
+      shallow(<Source src={src} imgProps={imgProps} sizes={sizes} />);
 
     shouldBehaveLikeSource(renderImage);
     it("props.srcSet should be set to a valid src", () => {
@@ -142,13 +140,7 @@ describe("When in <source> mode", () => {
   describe("with disableSrcSet prop", () => {
     const renderImage = () =>
       shallow(
-        <Imgix
-          src={src}
-          type="source"
-          disableSrcSet
-          imgProps={imgProps}
-          sizes={sizes}
-        />
+        <Source src={src} disableSrcSet imgProps={imgProps} sizes={sizes} />
       );
 
     shouldBehaveLikeSource(renderImage);
@@ -176,7 +168,7 @@ describe("When in picture mode", () => {
       expect(sut.props().alt).toBe(undefined);
     });
 
-    it("an <img> or a <ReactImgix type=img> should be the last child", () => {
+    it("an <img> or a <Imgix> should be the last child", () => {
       const lastChildElement = lastChild
         .first()
         .shallow() // hack from https://github.com/airbnb/enzyme/issues/539#issuecomment-239497107 until a better solution is implemented
@@ -194,9 +186,7 @@ describe("When in picture mode", () => {
     const oldConsole = global.console;
     global.console = { warn: jest.fn() };
 
-    shallow(
-      <Imgix src={src} type="picture" aggressiveLoad width={100} height={100} />
-    );
+    shallow(<Picture src={src} aggressiveLoad width={100} height={100} />);
 
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining("No fallback image found")
@@ -205,18 +195,17 @@ describe("When in picture mode", () => {
     global.console = oldConsole;
   });
 
-  describe("with a <ReactImgix type=img> passed as a child", () => {
+  describe("with a <Imgix> passed as a child", () => {
     beforeEach(() => {
       sut = shallow(
-        <Imgix
+        <Picture
           src={src}
-          type="picture"
           agressiveLoad
           imgixParams={{ crop: "faces" }}
           imgProps={{ alt: parentAlt }}
         >
-          <Imgix src={src} type="img" imgProps={{ alt: childAlt }} />
-        </Imgix>
+          <Imgix src={src} imgProps={{ alt: childAlt }} />
+        </Picture>
       );
       children = sut.children();
       lastChild = children.last();
@@ -227,7 +216,6 @@ describe("When in picture mode", () => {
       expect(children).toHaveLength(1);
     });
     it.skip("props should not be passed down to children", () => {
-      // TODO: Pass down imgixParams
       expect(
         lastChild
           .first()
@@ -247,14 +235,13 @@ describe("When in picture mode", () => {
   describe("with an <img> passed as a child", () => {
     beforeEach(() => {
       sut = shallow(
-        <Imgix
+        <Picture
           src={src}
-          type="picture"
           imgixParams={{ crop: "faces" }}
           imgProps={{ alt: parentAlt }}
         >
           <img src={src} alt={childAlt} />
-        </Imgix>
+        </Picture>
       );
       children = sut.children();
       lastChild = children.last();


### PR DESCRIPTION
BREAKING CHANGES: - picture and source types have been changed to components. 

## Description

**NB: This is currently a stacked PR. I will change the base to `version-8` when #162 is resolved. The last commit in the PR moved some stuff around, it may help to view [this diff](https://github.com/imgix/react-imgix/pull/163/files/0b88acb3f646691ef1df80b207b5e09935df54f5) first to see the feature changes.**

This PR builds on the changes described in #144. Having the picture and source behaviour work using a `type` prop was causing `<Imgix />` to have mixed responsibilities. This was causing pecularities, such as needing to pass a `src` to a `<Imgix type='picture' />` even though it wasn't used. 

### TODO 

- [x] Update Upgrade Guide
- [x] Change imgProps to be htmlAttributes as discussed offline with @jayeb 
~- [ ] Add prop fall-through behaviour to `<Picture />`~

### New Feature

- [x] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Update the readme
- [x] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Review the changes to the tests.
