### PR TITLE
feat: aspectRatio prop

### DIFF
--- a/src/HOCs/deprecatePropsHOC.js
+++ b/src/HOCs/deprecatePropsHOC.js
@@ -56,6 +56,7 @@ const deprecatePropsHOC = WrappedComponent => {
   };
   WithDeprecatedProps.propTypes = {
     ...WrappedComponent.propTypes,
+    aspectRatio: PropTypes.number,
     auto: PropTypes.array,
     customParams: PropTypes.object,
     crop: PropTypes.string,

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -32,6 +32,7 @@ const COMMON_PROP_TYPES = {
 
 const SHARED_IMGIX_AND_SOURCE_PROP_TYPES = {
   ...COMMON_PROP_TYPES,
+  aspectRatio: PropTypes.number,
   disableSrcSet: PropTypes.bool,
   disableLibraryParam: PropTypes.bool,
   imgixParams: PropTypes.object,
@@ -45,6 +46,7 @@ const SHARED_IMGIX_AND_SOURCE_PROP_TYPES = {
  * Build a imgix source url with parameters from a raw url
  */
 function buildSrc({
+  aspectRatio,
   src: rawSrc,
   width,
   height,
@@ -75,10 +77,14 @@ function buildSrc({
       srcSet = `${dpr2} 2x, ${dpr3} 3x`;
     } else {
       const buildSrcSetPair = targetWidth => {
-        const url = constructUrl(rawSrc, {
+        let urlParams = {
           ...srcOptions,
           width: targetWidth
-        });
+        };
+        if (!srcOptions.height && aspectRatio && aspectRatio > 0) {
+          urlParams.height = Math.floor(targetWidth / aspectRatio);
+        }
+        const url = constructUrl(rawSrc, urlParams);
         return `${url} ${targetWidth}w`;
       };
       const addFallbackSrc = srcSet => srcSet.concat(src);

--- a/test/unit/react-imgix.test.js
+++ b/test/unit/react-imgix.test.js
@@ -472,6 +472,38 @@ describe("When using the component", () => {
     expect(sut.props().width).toEqual(width);
   });
 
+  it("the aspectRatio prop should generate height query parameter", () => {
+    const aspectRatio = 1024 / 768;
+    sut = shallow(
+      <Imgix
+        src={src}
+        sizes="(max-width: 30em) 100vw, (max-width: 50em) 50vw"
+        aspectRatio={aspectRatio}
+      />
+    );
+
+    const srcSet = sut.props().srcSet;
+    const srcSets = srcSet.split(",").map(v => v.trim());
+    const srcSetUrls = srcSets.map(srcSet => srcSet.split(" ")[0]);
+    const parseParam = (str, param) => {
+      const matched = str.match("[?&]" + param + "=([^&]+)");
+      if (!matched) return null;
+      return parseInt(matched[1], 10);
+    };
+    srcSetUrls.forEach(srcSetUrl => {
+      const w = parseParam(srcSetUrl, "w");
+      const h = parseParam(srcSetUrl, "h");
+      if (w && h) {
+        expect(h).toEqual(Math.floor(w / aspectRatio));
+      }
+      if ((!w && h) || (w && !h)) {
+        fail(
+          "both width and height should be generated when aspectRatio is used"
+        );
+      }
+    });
+  });
+
   it("an alt attribute should be set given htmlAttributes.alt", async () => {
     const htmlAttributes = {
       alt: "Example alt attribute"


### PR DESCRIPTION
## Description

👋  
This is a WIP version and my first contribution, so I would appreciate any feedback and comments.

Aim of this PR is to introduce `aspectRatio` prop to extend generated `srcSets` with `height` parameter in addition to the `width`.
This behavior can be useful in cases where you want to crop renditions as well as use `srcSets`.
 
I am open to extend/modify this feature to align with general vision of `aspectRatio` and `srcSet` of core library contributors.

Related issue: #161 

### To-do

- [ ] Simplify and make easy to use `aspectRatio` prop to deal with floating point precision. i.e. providing `1.33` instead of `1024 / 768` would result into wrong heights generated, because of lack of precision. `1.3333333` on other hand is too tedious for users to provide. 
- [ ] Test usage of prop with `Picture` or other parts of `react-imgix`, i.e. providing different aspect ratios for art direction

### New Feature

- [x] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [ ] Update the readme
- [ ] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Usage

```js
// 'aspectRatio' has to be provided in the form of division;
// Looking into ways to improve/check for correct prop value.
const aspectRatio = 1024 / 768
<Imgix src={src} sizes="(max-width: 30em) 100vw, (max-width: 50em) 50vw" aspectRatio={aspectRatio} />
```
