### PR TITLE
feat: add HTML attribute configuration, enabling use of third-party libraries e.g. lazysizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ A [React](https://facebook.github.io/react/) component that renders images using
   - [Server-side rendering](#server-side-rendering)
   - [Flexible image rendering](#fixed-image-rendering-ie-non-flexible)
   - [Fixed image rendering](#fixed-image-rendering)
+  - [Lazy Loading](#lazy-loading)
+  - [Low Quality Image Placeholder Technique (LQIP)](#low-quality-image-placeholder-technique-lqip)
   - [Picture support](#picture-support)
   - [Background mode](#background-mode)
 - [Props](#props)
@@ -167,6 +169,49 @@ import Imgix from "react-imgix";
 ```
 
 [![Edit 4z1rzq04q7](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/4z1rzq04q7?view=preview)
+
+#### Lazy Loading
+
+If you'd like to lazy load images, we recommend using [lazysizes](https://github.com/aFarkas/lazysizes). In order to use react-imgix with lazysizes, you can simply tell it to generate lazysizes-compatible attributes instead of the standard `src`, `srcset`, and `sizes` by changing some configuration settings:
+
+```jsx
+<Imgix
+	className="lazyload"
+	src="..."
+	sizes="..."
+	attributeConfig={{
+		src: 'data-src',
+		srcSet: 'data-srcset'
+		sizes: 'data-sizes'
+	}}
+/>
+```
+
+The same configuration is available for `<Source />` components
+
+**NB:** It is recommended to use the [attribute change plugin](https://github.com/aFarkas/lazysizes/tree/gh-pages/plugins/attrchange) in order to capture changes in the data-\* attributes. Without this, changing the props to this library will have no effect on the rendered image.
+
+#### Low Quality Image Placeholder Technique (LQIP)
+
+If you'd like to use LQIP images, like before, we recommend using [lazysizes](https://github.com/aFarkas/lazysizes). In order to use react-imgix with lazysizes, you can simply tell it to generate lazysizes-compatible attributes instead of the standard `src`, `srcset`, and `sizes` by changing some configuration settings, and placing the fallback image src in the htmlAttributes:
+
+```jsx
+<Imgix
+	className="lazyload"
+	src="..."
+	sizes="..."
+	attributeConfig={{
+		src: 'data-src',
+		srcSet: 'data-srcset'
+		sizes: 'data-sizes'
+	}}
+	htmlAttributes={{
+		src: '...' // low quality image here
+	}}
+/>
+```
+
+**NB:** If the props of the image are changed after the first load, the low quality image will replace the high quality image. In this case, the `src` attribute may have to be set by modifying the DOM directly, or the lazysizes API may have to be called manually after the props are changed. In any case, this behaviour is not supported by the library maintainers, so use at your own risk.
 
 #### Picture support
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,20 @@ Any other attributes to add to the html node (example: `alt`, `data-*`, `classNa
 
 Called on `componentDidMount` with the mounted DOM node as an argument.
 
+##### attributeConfig :: object
+
+Allows the src, srcset, and sizes attributes to be remapped to different HTML attributes. For example:
+
+```js
+	attributeConfig={{
+		src: 'data-src',
+		srcSet: 'data-srcset'
+		sizes: 'data-sizes'
+	}}
+```
+
+This re-maps src to `data-src`, srcSet to `data-srcset`, etc.
+
 #### Picture Props
 
 ##### className :: string

--- a/src/HOCs/shouldComponentUpdateHOC.js
+++ b/src/HOCs/shouldComponentUpdateHOC.js
@@ -26,6 +26,9 @@ const ShouldComponentUpdateHOC = WrappedComponent => {
         if (key === "htmlAttributes") {
           return shallowEqual(oldProp, newProp);
         }
+        if (key === "attributeConfig") {
+          return shallowEqual(oldProp, newProp);
+        }
         return undefined; // handled by shallowEqual
       };
       const propsAreEqual = shallowEqual(props, nextProps, customizer);

--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -22,6 +22,12 @@ const defaultImgixParams = {
   fit: "crop"
 };
 
+const defaultAttributeMap = {
+  src: "src",
+  srcSet: "srcSet",
+  sizes: "sizes"
+};
+
 const noop = () => {};
 
 const COMMON_PROP_TYPES = {
@@ -153,16 +159,20 @@ class ReactImgix extends Component {
       imgixParams: imgixParams(this.props)
     });
 
-    let childProps = {
+    const attributeConfig = {
+      ...defaultAttributeMap,
+      ...this.props.attributeConfig
+    };
+    const childProps = {
       ...this.props.htmlAttributes,
-      sizes: this.props.sizes,
+      [attributeConfig.sizes]: this.props.sizes,
       className: this.props.className,
       width: width <= 1 ? null : width,
       height: height <= 1 ? null : height,
-      src
+      [attributeConfig.src]: src
     };
     if (!disableSrcSet) {
-      childProps.srcSet = srcSet;
+      childProps[attributeConfig.srcSet] = srcSet;
     }
 
     if (type === "bg") {
@@ -273,9 +283,13 @@ class SourceImpl extends Component {
       imgixParams: imgixParams(this.props)
     });
 
-    let childProps = {
+    const attributeConfig = {
+      ...defaultAttributeMap,
+      ...this.props.attributeConfig
+    };
+    const childProps = {
       ...this.props.htmlAttributes,
-      sizes: this.props.sizes,
+      [attributeConfig.sizes]: this.props.sizes,
       className: this.props.className,
       width: width <= 1 ? null : width,
       height: height <= 1 ? null : height
@@ -285,9 +299,9 @@ class SourceImpl extends Component {
     // attribute in favor of srcSet so we set that with either an actual
     // srcSet or a single src
     if (disableSrcSet) {
-      childProps.srcSet = src;
+      childProps[attributeConfig.srcSet] = src;
     } else {
-      childProps.srcSet = `${src}, ${srcSet}`;
+      childProps[attributeConfig.srcSet] = `${src}, ${srcSet}`;
     }
     // for now we'll take media from htmlAttributes which isn't ideal because
     //   a) this isn't an <img>

--- a/test/integration/react-imgix.test.js
+++ b/test/integration/react-imgix.test.js
@@ -93,7 +93,8 @@ describe("Lazysizes support", () => {
       <Imgix
         className="lazyload"
         src={src}
-        sizes="100vw"
+        width={100}
+        height={100}
         attributeConfig={{
           src: "data-src",
           srcSet: "data-srcset",
@@ -103,11 +104,12 @@ describe("Lazysizes support", () => {
     );
 
     const renderedImage = renderIntoContainer(component);
-    lazySizes.loader.unveil(renderedImage.getDOMNode());
+    const renderedImageElement = renderedImage.getDOMNode();
+    lazySizes.loader.unveil(renderedImageElement);
     await new Promise(resolve => setTimeout(resolve, 1)); // Timeout allows DOM to update
 
-    const actualSrc = renderedImage.getDOMNode().src;
-    const actualSrcSet = renderedImage.getDOMNode().srcset;
+    const actualSrc = renderedImageElement.getAttribute("src");
+    const actualSrcSet = renderedImageElement.getAttribute("srcset");
 
     expect(actualSrc).toContain(src);
     expect(actualSrcSet).toContain(src);
@@ -119,12 +121,13 @@ describe("Lazysizes support", () => {
     const script = await injectScript(
       "https://cdnjs.cloudflare.com/ajax/libs/lazysizes/4.1.2/lazysizes.min.js"
     );
-    const lqipSrc = `${src}?w=100&h=100`;
+    const lqipSrc = `${src}?w=10&h=10`;
     const component = (
       <Imgix
         className="lazyload"
         src={src}
-        sizes="100vw"
+        width={100}
+        height={100}
         attributeConfig={{
           src: "data-src",
           srcSet: "data-srcset",
@@ -137,15 +140,16 @@ describe("Lazysizes support", () => {
     );
 
     const renderedImage = renderIntoContainer(component);
+    const renderedImageElement = renderedImage.getDOMNode();
 
-    let actualSrc = renderedImage.getDOMNode().src;
+    let actualSrc = renderedImageElement.src;
     expect(actualSrc).toBe(lqipSrc);
 
-    lazySizes.loader.unveil(renderedImage.getDOMNode());
+    lazySizes.loader.unveil(renderedImageElement);
     await new Promise(resolve => setTimeout(resolve, 100)); // Timeout allows DOM to update
 
-    actualSrc = renderedImage.getDOMNode().src;
-    const actualSrcSet = renderedImage.getDOMNode().srcset;
+    actualSrc = renderedImageElement.getAttribute("src");
+    const actualSrcSet = renderedImageElement.getAttribute("srcset");
 
     expect(actualSrc).toContain(src);
     expect(actualSrcSet).toContain(src);

--- a/test/integration/react-imgix.test.js
+++ b/test/integration/react-imgix.test.js
@@ -146,7 +146,7 @@ describe("Lazysizes support", () => {
     expect(actualSrc).toBe(lqipSrc);
 
     lazySizes.loader.unveil(renderedImageElement);
-    await new Promise(resolve => setTimeout(resolve, 100)); // Timeout allows DOM to update
+    await new Promise(resolve => setTimeout(resolve, 8000)); // Timeout allows DOM to update
 
     actualSrc = renderedImageElement.getAttribute("src");
     const actualSrcSet = renderedImageElement.getAttribute("srcset");
@@ -155,5 +155,5 @@ describe("Lazysizes support", () => {
     expect(actualSrcSet).toContain(src);
 
     document.head.removeChild(script);
-  });
+  }).timeout(10000);
 });

--- a/test/unit/react-imgix.test.js
+++ b/test/unit/react-imgix.test.js
@@ -20,6 +20,8 @@ function shallow(element, target = __ReactImgixImpl, shallowOptions) {
     }
   });
 }
+const shallowSource = element => shallow(element, __SourceImpl);
+const shallowPicture = element => shallow(element, __PictureImpl);
 
 const src = "http://domain.imgix.net/image.jpg";
 let sut, vdom, instance;
@@ -104,7 +106,6 @@ describe("When in image mode", () => {
 });
 
 describe("When in <source> mode", () => {
-  const shallowSource = element => shallow(element, __SourceImpl);
   const sizes =
     "(max-width: 30em) 100vw, (max-width: 50em) 50vw, calc(33vw - 100px)";
   const htmlAttributes = {
@@ -200,7 +201,6 @@ describe("When in <source> mode", () => {
 });
 
 describe("When in picture mode", () => {
-  const shallowPicture = element => shallow(element, __PictureImpl);
   let children, lastChild;
   const parentAlt = "parent alt";
   const childAlt = "child alt";
@@ -517,6 +517,47 @@ describe("When using the component", () => {
     );
 
     expectSrcsTo(sut, expect.not.stringContaining(`ixlib=`));
+  });
+});
+
+describe("Attribute config", () => {
+  describe("<Imgix />", () => {
+    const ATTRIBUTES = ["src", "srcSet", "sizes"];
+    ATTRIBUTES.forEach(ATTRIBUTE => {
+      it(`${ATTRIBUTE} can be configured to use data-${ATTRIBUTE}`, () => {
+        sut = shallow(
+          <Imgix
+            src="https://mysource.imgix.net/demo.png"
+            sizes="100vw"
+            attributeConfig={{
+              [ATTRIBUTE]: `data-${ATTRIBUTE}`
+            }}
+          />
+        );
+
+        expect(sut.props()[`data-${ATTRIBUTE}`]).not.toBeUndefined();
+        expect(sut.props()[ATTRIBUTE]).toBeUndefined();
+      });
+    });
+  });
+  describe("<Source />", () => {
+    const ATTRIBUTES = ["srcSet", "sizes"];
+    ATTRIBUTES.forEach(ATTRIBUTE => {
+      it(`${ATTRIBUTE} can be configured to use data-${ATTRIBUTE}`, () => {
+        sut = shallowSource(
+          <Source
+            src="https://mysource.imgix.net/demo.png"
+            sizes="100vw"
+            attributeConfig={{
+              [ATTRIBUTE]: `data-${ATTRIBUTE}`
+            }}
+          />
+        );
+
+        expect(sut.props()[`data-${ATTRIBUTE}`]).not.toBeUndefined();
+        expect(sut.props()[ATTRIBUTE]).toBeUndefined();
+      });
+    });
   });
 });
 describe("deprecations", () => {


### PR DESCRIPTION
## Description

This PR allows the HTML attributes that are set by this library, such as `src` and `srcset`, to be re-mapped to other attributes. This allows developers to include other libraries, such as lazysizes, and use them in conjunction with this library. This follows the same pattern as what is used in imgix.js.

As I envision many people will want to use lazysizes with this library, I have added some integration tests to ensure that lazy loading and LQIP works with this library.

For the structure of the `attributeConfig` prop, please see the changes to the README.

Fixes #117 

## New Feature

- [N/A] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Update the readme
- [x] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Review changes to the tests, including the integration tests (wow!)