### PR TITLE
chore(renovate): update config to force lib mode

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["config:base"]
+  "extends": ["config:js-lib"]
 }


### PR DESCRIPTION
## Description

This PR updates the Renovate config to force it to operate in lib mode. This ensures that only dev dependencies are pinned.
