### PR TITLE
chore(renovate): enable auto-merging

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,9 @@
 {
-  "extends": ["config:js-lib"]
+  "extends": ["config:js-lib"],
+  "automerge": true,
+  "automergeType": "pr-comment",
+  "automergeComment": "@bors: r+",
+  "patch": {
+    "automerge": true
+  }
 }


### PR DESCRIPTION
## Description

This PR enables auto-merging of Renovate PRs under two circumstances:

- if the version update is a patch update, then automerge straight away
- if not a patch update, then wait for a PR comment with "@bors: r+", and then automerge