### PR TITLE
chore: add 4x and 5x dprs in srcset

### DIFF
--- a/src/react-imgix.js
+++ b/src/react-imgix.js
@@ -96,7 +96,9 @@ function buildSrc({
     if (fixedSize || type === "source") {
       const dpr2 = constructUrl(rawSrc, { ...srcOptions, dpr: 2 });
       const dpr3 = constructUrl(rawSrc, { ...srcOptions, dpr: 3 });
-      srcSet = `${dpr2} 2x, ${dpr3} 3x`;
+      const dpr4 = constructUrl(rawSrc, { ...srcOptions, dpr: 4 });
+      const dpr5 = constructUrl(rawSrc, { ...srcOptions, dpr: 5 });
+      srcSet = `${dpr2} 2x, ${dpr3} 3x, ${dpr4} 4x, ${dpr5} 5x`;
     } else {
       let showARWarning = false;
       const buildSrcSetPair = targetWidth => {

--- a/test/unit/react-imgix.test.js
+++ b/test/unit/react-imgix.test.js
@@ -150,16 +150,18 @@ describe("When in <source> mode", () => {
     it("props.srcSet should be set to a valid src", () => {
       expect(renderImage().props().srcSet).toContain(src);
     });
-    it("srcSet should be in the form src, src 2x, src 3x", () => {
+    it("srcSet should be in the form src, src 2x, src 3x, src 4x, src 5x", () => {
       const srcSet = renderImage().props().srcSet;
 
       const srcSets = srcSet.split(", ");
-      expect(srcSets).toHaveLength(3);
+      expect(srcSets).toHaveLength(5);
       srcSets.forEach(srcSet => {
         expect(srcSet).toContain(src);
       });
       expect(srcSets[1].split(" ")[1]).toBe("2x");
       expect(srcSets[2].split(" ")[1]).toBe("3x");
+      expect(srcSets[3].split(" ")[1]).toBe("4x");
+      expect(srcSets[4].split(" ")[1]).toBe("5x");
     });
   });
 


### PR DESCRIPTION
## Description

This PR adds 4x and 5x dprs to the srcsets when using fixed dimension rendering. This allows images to look even better on new high-dpr devices.

### New Feature

- [N/A] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [N/A] Update the readme
- [x] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Check that tests are still passing.