### PR TITLE
test(background-mode): fix incorrect test and remove .only

### DIFF
--- a/test/integration/react-imgix.test.jsx
+++ b/test/integration/react-imgix.test.jsx
@@ -222,9 +222,6 @@ describe("Background Mode", () => {
       shouldRenderNoBGImage(
         <Background
           src={`${src}`}
-          imgixParams={{
-            w: 200
-          }}
           className="bg-img"
         >
           <div>Content</div>
@@ -426,7 +423,7 @@ describe("Background Mode", () => {
     });
   });
 
-  it.only("scales the background image by the devices dpr", async () => {
+  it("scales the background image by the devices dpr", async () => {
     // window.devicePixelRatio is not allowed in IE.
     if (isIE) {
       return;

--- a/test/integration/react-imgix.test.jsx
+++ b/test/integration/react-imgix.test.jsx
@@ -220,10 +220,7 @@ describe("Background Mode", () => {
   describe("when neither width nor height are passed", () => {
     it("renders nothing at first", () => {
       shouldRenderNoBGImage(
-        <Background
-          src={`${src}`}
-          className="bg-img"
-        >
+        <Background src={`${src}`} className="bg-img">
           <div>Content</div>
         </Background>
       );


### PR DESCRIPTION
The background mode PR slipped through with a few mistakes in the tests. This fixes them.