### PR TITLE
feat: support variable qualities #129

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,13 +388,25 @@ Force images to be a certain height.
 
 Force images to be a certain width.
 
-##### disableSrcSet :: bool, default = false
-
-Disable generation of variable width src sets to enable responsiveness.
-
 ##### disableLibraryParam :: bool
 
 By default this component adds a parameter to the generated url to help imgix with analytics and support for this library. This can be disabled by setting this prop to `true`.
+
+##### genSrcSet :: bool | array, default = true
+
+As a boolean, enable generation of variable width src sets to enable responsiveness. As an array, enable generation of variable width src sets and allows setting of different imgix params to each src in the src set.
+
+_For example_:
+
+```js
+import Imgix from "react-imgix";
+
+// As a boolean. Disables generation of variable width src sets.
+<Imgix src="https://assets.imgix.net/examples/pione.jpg" genSrcSet={false} />;
+
+// As an array.
+<Imgix src="https://assets.imgix.net/examples/pione.jpg" genSrcSet={[{q: 95, dpr: 1}, {q: 75, dpr: 2}, {q: 50, dpr: 3}]} />;
+```
 
 ##### htmlAttributes :: object
 
@@ -488,6 +500,12 @@ The warnings available are:
 | sizesAttribute | This library requires a `sizes` prop to be passed so that the images can render responsively. This should only turned off in very special circumstances.                                                                        |
 
 ## Upgrade Guides
+
+### 8.5.1 to 8.6
+
+To upgrade to version 8.6, the following changes should be made.
+
+- Rename `disableSrcSet` to `genSrcSet` and invert the value passed down as the prop's value. i.e. `disableSrcSet={false}` becomes `genSrcSet={true}` or simply `genSrcSet`
 
 ### 7.x to 8.0
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)",
   "contributors": [
     "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)",
-    "Max Kolyanov (https://github.com/maxkolyanov)"
+    "Max Kolyanov (https://github.com/maxkolyanov)",
+    "zachafranz"
   ],
   "license": "ISC",
   "bugs": {

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -38,7 +38,7 @@ const COMMON_PROP_TYPES = {
 
 const SHARED_IMGIX_AND_SOURCE_PROP_TYPES = {
   ...COMMON_PROP_TYPES,
-  disableSrcSet: PropTypes.bool,
+  genSrcSet: PropTypes.bool,
   disableLibraryParam: PropTypes.bool,
   imgixParams: PropTypes.object,
   sizes: PropTypes.string,
@@ -72,7 +72,7 @@ function buildSrc({
   width,
   height,
   disableLibraryParam,
-  disableSrcSet,
+  genSrcSet,
   type,
   imgixParams,
   aspectRatio
@@ -90,7 +90,7 @@ function buildSrc({
 
   let srcSet;
 
-  if (disableSrcSet) {
+  if (genSrcSet === false) {
     srcSet = src;
   } else {
     if (fixedSize || type === "source") {
@@ -168,7 +168,7 @@ class ReactImgix extends Component {
     ...SHARED_IMGIX_AND_SOURCE_PROP_TYPES
   };
   static defaultProps = {
-    disableSrcSet: false,
+    genSrcSet: true,
     onMounted: noop
   };
 
@@ -178,7 +178,7 @@ class ReactImgix extends Component {
   };
 
   render() {
-    const { disableSrcSet, type, width, height } = this.props;
+    const { genSrcSet, type, width, height } = this.props;
 
     // Pre-render checks
     if (NODE_ENV !== "production" && config.warnings.sizesAttribute) {
@@ -215,7 +215,7 @@ class ReactImgix extends Component {
       height: height <= 1 ? null : height,
       [attributeConfig.src]: src
     };
-    if (!disableSrcSet) {
+    if (genSrcSet !== false) {
       childProps[attributeConfig.srcSet] = srcSet;
     }
 
@@ -307,7 +307,7 @@ class SourceImpl extends Component {
     ...SHARED_IMGIX_AND_SOURCE_PROP_TYPES
   };
   static defaultProps = {
-    disableSrcSet: false,
+    genSrcSet: true,
     onMounted: noop
   };
 
@@ -316,7 +316,7 @@ class SourceImpl extends Component {
     this.props.onMounted(node);
   };
   render() {
-    const { disableSrcSet, width, height } = this.props;
+    const { genSrcSet, width, height } = this.props;
 
     const htmlAttributes = this.props.htmlAttributes || {};
 
@@ -341,7 +341,7 @@ class SourceImpl extends Component {
     // inside of a <picture> element a <source> element ignores its src
     // attribute in favor of srcSet so we set that with either an actual
     // srcSet or a single src
-    if (disableSrcSet) {
+    if (genSrcSet === false) {
       childProps[attributeConfig.srcSet] = src;
     } else {
       childProps[attributeConfig.srcSet] = `${src}, ${srcSet}`;

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -38,7 +38,7 @@ const COMMON_PROP_TYPES = {
 
 const SHARED_IMGIX_AND_SOURCE_PROP_TYPES = {
   ...COMMON_PROP_TYPES,
-  genSrcSet: PropTypes.bool,
+  genSrcSet: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
   disableLibraryParam: PropTypes.bool,
   imgixParams: PropTypes.object,
   sizes: PropTypes.string,
@@ -62,6 +62,22 @@ function parseAspectRatio(aspectRatio) {
   const [width, height] = aspectRatio.split(":");
 
   return parseFloat(width) / parseFloat(height);
+}
+
+/**
+ * Return an imgix options object with the corresponding dpr value. If there is none return an empty object.
+ */
+function getDprSpecificOptions(optionsArray, dpr) {
+  if (!Array.isArray(optionsArray)) {
+    return {};
+  }
+
+  const optionsObject = optionsArray.find((obj) => obj.dpr == dpr);
+  if (optionsObject === undefined) {
+    return {};
+  }
+
+  return optionsObject;
 }
 
 /**
@@ -94,10 +110,10 @@ function buildSrc({
     srcSet = src;
   } else {
     if (fixedSize || type === "source") {
-      const dpr2 = constructUrl(rawSrc, { ...srcOptions, dpr: 2 });
-      const dpr3 = constructUrl(rawSrc, { ...srcOptions, dpr: 3 });
-      const dpr4 = constructUrl(rawSrc, { ...srcOptions, dpr: 4 });
-      const dpr5 = constructUrl(rawSrc, { ...srcOptions, dpr: 5 });
+      const dpr2 = constructUrl(rawSrc, { ...srcOptions, ...getDprSpecificOptions(genSrcSet, 2), dpr: 2 });
+      const dpr3 = constructUrl(rawSrc, { ...srcOptions, ...getDprSpecificOptions(genSrcSet, 3), dpr: 3 });
+      const dpr4 = constructUrl(rawSrc, { ...srcOptions, ...getDprSpecificOptions(genSrcSet, 4), dpr: 4 });
+      const dpr5 = constructUrl(rawSrc, { ...srcOptions, ...getDprSpecificOptions(genSrcSet, 5), dpr: 5 });
       srcSet = `${dpr2} 2x, ${dpr3} 3x, ${dpr4} 4x, ${dpr5} 5x`;
     } else {
       let showARWarning = false;


### PR DESCRIPTION
## Description
Adds support for supplying variable imgix parameters to each of the different dpr urls generated in the srcset.

Would revert back to using `genSrcSet` (instead of the currently used prop `disableSrcSet`) as the prop to enable/disable generate of the different dpr urls for srcset. `genSrcSet` could either be a boolean, true to generate variable width srcset and false to not generate variable width srcset, or an array to generate variable width srcset with the ability to add custom imgix props for individual srcs in the srcset.

Compared to the original [issue](https://github.com/imgix/react-imgix/issues/129) opened, this feature would not allow the user to specify additional and custom dpr values for the srcset.

The addition of the feature would deprecate `disableSrcSet` and replace it with `genSrcSet` as well as flip the logic of the prop.

No new tests were added.

## Checklist
### New Feature
- [ x ] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [ x ] Run unit tests to ensure all existing tests are still passing
- [   ] Add new passing unit tests to cover the code introduced by your PR
- [ x ] Update the readme
- [ x ] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [ x ] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [ x ] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test
1. Use the following code in any preferred sandbox environment 
```js
import Imgix from "react-imgix";

<Imgix src="https://assets.imgix.net/examples/pione.jpg" genSrcSet={[{q: 95, dpr: 1}, {q: 75, dpr: 2}, {q: 50, dpr: 3}]} />;
```
2. Inspect the element to see variable qualities on each of the srcs in the srcset. Srcs with dpr 4 and 5 will have `q` of 95 as the `q` of the dpr 1 src acts as a default.