### PR TITLE
fix: ensure fit parameter will respect overriding value fixes #268

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)",
   "contributors": [
     "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)",
-    "Max Kolyanov (https://github.com/maxkolyanov)"
+    "Max Kolyanov (https://github.com/maxkolyanov)",
+    "Sherwin Heydarbeygi <sherwin@imgix.com> (https://github.com/sherwinski)" 
   ],
   "license": "ISC",
   "bugs": {

--- a/src/react-imgix-bg.jsx
+++ b/src/react-imgix-bg.jsx
@@ -84,11 +84,11 @@ const BackgroundImpl = props => {
 
   const renderedSrc = (() => {
     const srcOptions = {
+      fit: "crop",
       ...imgixParams,
       ...(disableLibraryParam ? {} : { ixlib: `react-${PACKAGE_VERSION}` }),
       width,
       height,
-      fit: "crop",
       dpr
     };
 

--- a/test/integration/react-imgix.test.jsx
+++ b/test/integration/react-imgix.test.jsx
@@ -559,6 +559,31 @@ describe("Background Mode", () => {
     expect(ref instanceof HTMLElement).toBe(true);
     expect(findURIfromSUT(sut).getQueryParamValue("w")).toBe("100");
   });
+  it("the fit parameter defaults to 'crop'", async () => {
+    const sut = await renderBGAndWaitUntilLoaded(
+      <div>
+        <Background src={src} className="bg-img">
+          <div>Content</div>
+        </Background>
+      </div>
+    );
+
+    const bgImageSrcURL = findURIfromSUT(sut);
+    expect(bgImageSrcURL.getQueryParamValue("fit")).toBe("crop");
+  });
+  it("the fit parameter can be overriden", async () => {
+    const sut = await renderBGAndWaitUntilLoaded(
+      <div>
+        <Background src={src} className="bg-img"
+        imgixParams = {{ fit: "clip" }}>
+          <div>Content</div>
+        </Background>
+      </div>
+    );
+
+    const bgImageSrcURL = findURIfromSUT(sut);
+    expect(bgImageSrcURL.getQueryParamValue("fit")).toBe("clip");
+  });
 });
 
 function injectScript(src) {

--- a/test/integration/react-imgix.test.jsx
+++ b/test/integration/react-imgix.test.jsx
@@ -574,8 +574,7 @@ describe("Background Mode", () => {
   it("the fit parameter can be overriden", async () => {
     const sut = await renderBGAndWaitUntilLoaded(
       <div>
-        <Background src={src} className="bg-img"
-        imgixParams = {{ fit: "clip" }}>
+        <Background src={src} className="bg-img" imgixParams={{ fit: "clip" }}>
           <div>Content</div>
         </Background>
       </div>


### PR DESCRIPTION
## Description

Any attempt to override the `fit` parameter when using a `Background` component will have no effect. Example + steps to reproduce can be found in #268.
Big thanks to @verbeeksteven for catching this and getting the ball rolling with #270.

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Update the readme
- [x] Update or add any necessary API documentation
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test
Can be found under `test/integration/react-imgix.test.jsx`