### PR TITLE
fix(deps): pin react-measure version to avoid regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "js-base64": "^2.3.2",
     "jsuri": "^1.3.1",
-    "react-measure": "^2.1.3",
+    "react-measure": "2.1.3 - 2.2.5",
     "shallowequal": "^1.1.0",
     "warning": "^4.0.1"
   },


### PR DESCRIPTION
## Description
Resolves #341 

There appears to be a regression in [react-measure](https://www.npmjs.com/package/react-measure) v2.2.6 that is causing `contentRect.bounds.width` and `contentRect.bounds.height` to return 0 in [react-imgix-bg](https://github.com/imgix/react-imgix/blob/15b0073f7b14679ebd6c43c1cf79bfb9c64b35c2/src/react-imgix-bg.jsx#L50). This causes the `<Background>` component to render without a `background-image` property. 

This PR will pin the version of react-measure to <2.2.6 in the meantime while we gather more information over at https://github.com/souporserious/react-measure/issues/137 

## Steps to Test
A comparison of react-measure [v2.2.6](https://codesandbox.io/s/3vv22zopj6) versus [v2.2.5](https://codesandbox.io/s/zk86221wq4)