### PR TITLE
Fix docs on how to add a class to an img element

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ By default this component adds a parameter to the generated url to help imgix wi
 
 ##### htmlAttributes :: object
 
-Any other attributes to add to the html node (example: `alt`, `data-*`, `className`).
+Any other attributes to add to the html node (example: `alt`, `data-*`, `class`).
 
 ##### onMounted :: func
 
@@ -451,7 +451,7 @@ Called on `componentDidMount` with the mounted DOM node as an argument.
 
 ##### htmlAttributes :: object
 
-Any other attributes to add to the html node (example: `alt`, `data-*`, `className`).
+Any other attributes to add to the html node (example: `alt`, `data-*`, `class`).
 
 #### Background Props
 


### PR DESCRIPTION
Looks like `htmlAttributes={{ className: 'foo' }}` is not working as expected. I tried `htmlAttributes={{ class: 'foo' }}` and worked fine.
