### PR TITLE
fix: render <Source> element as a fluid image by default

### DIFF
--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -131,7 +131,7 @@ function buildSrc({
   if (disableSrcSet) {
     srcSet = src;
   } else {
-    if (fixedSize || type === "source") {
+    if (fixedSize) {
       const { q: qOption, ...urlParams } = srcOptions;
 
       // Get the q from the raw src.
@@ -386,7 +386,7 @@ class SourceImpl extends Component {
     if (disableSrcSet) {
       childProps[attributeConfig.srcSet] = src;
     } else {
-      childProps[attributeConfig.srcSet] = `${src}, ${srcSet}`;
+      childProps[attributeConfig.srcSet] = `${srcSet}`;
     }
     // for now we'll take media from htmlAttributes which isn't ideal because
     //   a) this isn't an <img>

--- a/src/targetWidths.js
+++ b/src/targetWidths.js
@@ -10,7 +10,7 @@ function targetWidths() {
     resolutions.push(ensureEven(prev));
     prev *= 1 + (INCREMENT_PERCENTAGE / 100) * 2;
   }
-  
+
   resolutions.push(MAX_SIZE);
   return resolutions;
 }

--- a/src/targetWidths.js
+++ b/src/targetWidths.js
@@ -6,12 +6,12 @@ function targetWidths() {
 
   const ensureEven = n => 2 * Math.round(n / 2);
 
-  resolutions.push(prev);
   while (prev <= MAX_SIZE) {
-    prev *= 1 + (INCREMENT_PERCENTAGE / 100) * 2;
     resolutions.push(ensureEven(prev));
+    prev *= 1 + (INCREMENT_PERCENTAGE / 100) * 2;
   }
-
+  
+  resolutions.push(MAX_SIZE);
   return resolutions;
 }
 

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -237,19 +237,60 @@ describe("When in <source> mode", () => {
     it("props.srcSet should be set to a valid src", () => {
       expect(renderImage().props().srcSet).toContain(src);
     });
+
+    it("should have a srcSet set correctly", async () => {
+      const srcset = renderImage().props().srcSet;
+      expect(srcset).not.toBeUndefined();
+      expect(srcset.split(", ")[0].split(" ")).toHaveLength(2);
+      const aSrcFromSrcSet = srcset.split(", ")[0].split(" ")[0];
+      expect(aSrcFromSrcSet).toContain(src);
+      const aWidthFromSrcSet = srcset.split(", ")[0].split(" ")[1];
+      expect(aWidthFromSrcSet).toMatch(/^\d+w$/);
+    });
+
+    it("returns the expected number of `url widthDescriptor` pairs", function() {
+      const srcset = renderImage().props().srcSet;
+
+      expect(srcset.split(",").length).toEqual(targetWidths.length);
+    });
+
+    it("should not exceed the bounds of [100, 8192]", () => {
+      const srcset = renderImage().props().srcSet;
+
+      const srcsetWidths = srcset
+        .split(", ")
+        .map(srcset => srcset.split(" ")[1])
+        .map(width => width.slice(0, -1))
+        .map(Number.parseFloat);
+
+      const min = Math.min(...srcsetWidths);
+      const max = Math.max(...srcsetWidths);
+
+      expect(min).not.toBeLessThan(100);
+      expect(min).not.toBeGreaterThan(8192);
+    });
+  });
+
+  describe("in fixed width mode", () => {
+    const renderImage = () => {
+      return shallowSource(
+        <Source src={src} width = {100} htmlAttributes={htmlAttributes} sizes={sizes} />
+      );
+    };
+
     it("srcSet should be in the form src, src 2x, src 3x, src 4x, src 5x", () => {
       const srcSet = renderImage().props().srcSet;
 
       const srcSets = srcSet.split(", ");
-      expect(srcSets).toHaveLength(6);
+      expect(srcSets).toHaveLength(5);
       srcSets.forEach(srcSet => {
         expect(srcSet).toContain(src);
       });
-      expect(srcSets[1].split(" ")[1]).toBe("1x");
-      expect(srcSets[2].split(" ")[1]).toBe("2x");
-      expect(srcSets[3].split(" ")[1]).toBe("3x");
-      expect(srcSets[4].split(" ")[1]).toBe("4x");
-      expect(srcSets[5].split(" ")[1]).toBe("5x");
+      expect(srcSets[0].split(" ")[1]).toBe("1x");
+      expect(srcSets[1].split(" ")[1]).toBe("2x");
+      expect(srcSets[2].split(" ")[1]).toBe("3x");
+      expect(srcSets[3].split(" ")[1]).toBe("4x");
+      expect(srcSets[4].split(" ")[1]).toBe("5x");
     });
   });
 

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -105,7 +105,7 @@ describe("When in default mode", () => {
       const max = Math.max(...srcsetWidths);
 
       expect(min).not.toBeLessThan(100);
-      expect(min).not.toBeGreaterThan(8192);
+      expect(max).not.toBeGreaterThan(8192);
     });
 
     // 18% used to allow +-1% for rounding
@@ -267,7 +267,7 @@ describe("When in <source> mode", () => {
       const max = Math.max(...srcsetWidths);
 
       expect(min).not.toBeLessThan(100);
-      expect(min).not.toBeGreaterThan(8192);
+      expect(max).not.toBeGreaterThan(8192);
     });
   });
 

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -274,11 +274,16 @@ describe("When in <source> mode", () => {
   describe("in fixed width mode", () => {
     const renderImage = () => {
       return shallowSource(
-        <Source src={src} width = {100} htmlAttributes={htmlAttributes} sizes={sizes} />
+        <Source
+          src={src}
+          width={100}
+          htmlAttributes={htmlAttributes}
+          sizes={sizes}
+        />
       );
     };
 
-    it("srcSet should be in the form src, src 2x, src 3x, src 4x, src 5x", () => {
+    it("srcSet should be in the form src 1x, src 2x, src 3x, src 4x, src 5x", () => {
       const srcSet = renderImage().props().srcSet;
 
       const srcSets = srcSet.split(", ");


### PR DESCRIPTION
Resolves #243 

Previously, `<Source>` elements were generated with a `srcSet` attribute defined in DPR mode by default, regardless of whether a width and/or height prop were passed in.

This PR modifies the `srcSet` generation in `<Source>` elements to mimic the same behavior as responsive images generated by the `<Imgix>` component. Now the `srcSet` will be generated with width descriptors by default unless either or both dimensions are defined.

In addition, this PR addresses two bugs:
- the <Source> component was appending the fallback `src` to the `srcSet` attribute
- the largest responsive width generated in a given `srcSet` was greater than the enforced `max_width`