### PR TITLE
perf: constructUrl optimization

### DIFF
--- a/src/constructUrl.js
+++ b/src/constructUrl.js
@@ -105,17 +105,6 @@ var DEFAULT_OPTIONS = Object.freeze({
   auto: "format" // http://www.imgix.com/docs/reference/automatic#param-auto
 });
 
-function constructUrlFromParams(src, params) {
-  const keys = Object.keys(params);
-  const keysLength = keys.length;
-  let url = src + "?";
-  for (let i = 0; i < keysLength; i++) {
-    const key = keys[i];
-    url += key + "=" + encodeURIComponent(params[key]) + "&";
-  }
-  return url.slice(0, -1);
-}
-
 /**
  * Construct a URL for an image with an Imgix proxy, expanding image options
  * per the [API reference docs](https://www.imgix.com/docs/reference).
@@ -128,27 +117,27 @@ function constructUrl(src, longOptions) {
     return "";
   }
 
-  const shortOptions = Object.assign({}, DEFAULT_OPTIONS);
   const keys = Object.keys(longOptions);
   const keysLength = keys.length;
+  let url = src + "?";
   for (let i = 0; i < keysLength; i++) {
     let key = keys[i];
     let val = longOptions[key];
 
     if (PARAM_EXPANSION[key]) {
       key = PARAM_EXPANSION[key];
+    } else {
+      key = encodeURIComponent(key);
     }
-
-    key = encodeURIComponent(key);
 
     if (key.substr(-2) === "64") {
       val = Base64.encodeURI(val);
     }
 
-    shortOptions[key] = val;
+    url += key + "=" + encodeURIComponent(val) + "&";
   }
 
-  return constructUrlFromParams(src, shortOptions);
+  return url.slice(0, -1);
 }
 
 function buildURLPublic(src, imgixParams = {}, options = {}) {


### PR DESCRIPTION
I know this is getting old 😅 But I noticed a missed opportunity in `constructUrl` so here it is. I hope to focus on other parts of the code after this 😊

Combines `constructUrl` and `constructUrlFromParams`.
Since `constructUrl` was the only function using `constructUrlFromParams`.
Combining these functions removes one loop over params 🙌🏻

Profiling results in milliseconds. 100,000 iterations

|                                       | before   | after    | Change  |
|---------------------------------------|----------|----------|---------|
| responsive                            | 1960.634 | 1611.956 | -17.78% |
| responsive with fixed height          | 1743.363 | 1302.794 | -25.27% |
| responsive with aspect ratio          | 2781.415 | 1687.540 | -39.33% |
| fixed width                           | 1887.064 | 1281.796 | -32.07% |
| fixed width with quality              | 2062.505 | 1288.447 | -37.53% |
| fixed width with dpr quality disabled | 1738.201 | 1126.015 | -35.22% |
| fixed width with aspect ratio         | 1927.686 | 1279.570 | -33.62% |

[Flamegraph before](https://upload.clinicjs.org/public/14d4b66989154b7d7c45dc47b6f363ba002cef2caa3bd34f7beb1c499d21d647/2967.clinic-flame.html#selectedNode=643&zoomedNode=&exclude=83c0&showOptimizationStatus=true)
[Flamegraph after](https://upload.clinicjs.org/public/c19d5af26298a5fdc17390782845d5cb7c15c42ea10c21cff6fa727c8c22d266/2179.clinic-flame.html#selectedNode=735&zoomedNode=&exclude=83c0&showOptimizationStatus=true)

According to the flamegraph `constructUrl` is still not "optimized" but it’s no longer the hottest frame and I’m out of ideas 😄

