### PR TITLE
refactor: use ar parameter instead of calculating aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ import "./styles.css";
 [![Edit xp0348lv0z](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/charming-keller-kjnsq)
 
 **Aspect Ratio:** A developer can pass a desired aspect ratio, which will be used when
-generating srcsets to generate the correct height, according to the aspect ratio.
+generating srcsets to resize and crop your image as specified. For the `ar` parameter to take effect, ensure that the `fit` parameter is set to `crop`.
 
 ```js
 <div className="App">

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -73,21 +73,6 @@ function parseAspectRatio(aspectRatio) {
 const buildSrcSetPairWithFixedHeight = (url, targetWidth, fixedHeight, _) =>
   url + "&h=" + fixedHeight + "&w=" + targetWidth + " " + targetWidth + "w";
 
-const buildSrcSetPairWithAspectRatio = (
-  url,
-  targetWidth,
-  _,
-  aspectRatioDecimal
-) =>
-  url +
-  "&h=" +
-  Math.ceil(targetWidth / aspectRatioDecimal) +
-  "&w=" +
-  targetWidth +
-  " " +
-  targetWidth +
-  "w";
-
 const buildSrcSetPairWithTargetWidth = (url, targetWidth, _1, _2) =>
   url + "&w=" + targetWidth + " " + targetWidth + "w";
 
@@ -111,7 +96,6 @@ function buildSrc({
   disableSrcSet,
   type,
   imgixParams,
-  aspectRatio,
   disableQualityByDPR
 }) {
   const fixedSize = width != null || height != null;
@@ -156,6 +140,7 @@ function buildSrc({
       const { width, w, height, ...urlParams } = srcOptions;
       const constructedUrl = constructUrl(rawSrc, urlParams);
 
+      const aspectRatio = imgixParams.ar;
       const aspectRatioDecimal = parseAspectRatio(aspectRatio);
       // false indicates invalid
       let showARWarning = aspectRatio != null && aspectRatioDecimal === false;
@@ -163,15 +148,14 @@ function buildSrc({
       let srcFn = buildSrcSetPairWithTargetWidth;
       if (height) {
         srcFn = buildSrcSetPairWithFixedHeight;
-      } else if (aspectRatioDecimal) {
-        srcFn = buildSrcSetPairWithAspectRatio;
       }
+
       srcSet = "";
       const len = targetWidths.length;
       for (let i = 0; i < len; i++) {
         const targetWidth = targetWidths[i];
         srcSet +=
-          srcFn(constructedUrl, targetWidth, height, aspectRatioDecimal) + ", ";
+          srcFn(constructedUrl, targetWidth, height) + ", ";
       }
       srcSet = srcSet.slice(0, -2);
 
@@ -199,9 +183,6 @@ function imgixParams(props) {
   if (params.crop != null) fit = "crop";
   if (params.fit) fit = params.fit;
 
-  if (params.ar) {
-    delete params.ar;
-  }
 
   return Object.assign({}, params, { fit });
 }
@@ -244,7 +225,6 @@ class ReactImgix extends Component {
       Object.assign({}, this.props, {
         type: "img",
         imgixParams: imgixParams(this.props),
-        aspectRatio: (this.props.imgixParams || {}).ar
       })
     );
 

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -627,8 +627,8 @@ describe("When using the component", () => {
 
   describe("aspectRatio", () => {
     describe("valid AR", () => {
-      const testValidAR = ({ ar, arDecimal }) => {
-        it(`a valid ar prop (${ar}) should generate height query parameter`, () => {
+      const testValidAR = ({ ar }) => {
+        it(`a valid ar prop (${ar}) should generate an ar query parameter`, () => {
           const parseParam = (url, param) => {
             const matched = url.match("[?&]" + param + "=([^&]+)");
             if (!matched) return undefined;
@@ -648,43 +648,39 @@ describe("When using the component", () => {
           const srcSets = srcSet.split(",").map(v => v.trim());
           const srcSetUrls = srcSets.map(srcSet => srcSet.split(" ")[0]);
           removeFallbackSrcSet(srcSetUrls).forEach(srcSetUrl => {
-            const w = parseParam(srcSetUrl, "w");
-            const h = parseParam(srcSetUrl, "h");
+            const ar = parseParam(srcSetUrl, "ar");
 
-            expect(h).toEqual(Math.ceil(w / arDecimal));
-            expect(w).toBeTruthy();
-            expect(h).toBeTruthy();
+            expect(ar).toBeTruthy();
           });
         });
       };
       [
-        ["1:1", "1"],
-        ["1.1:1", "1.1"],
-        ["1.12:1", "1.12"],
-        ["1.123:1", "1.123"],
-        ["1:1.1", "0.9090909090909091"],
-        ["1:1.12", "0.8928571428571428"],
-        ["1.1:1.1", "1"],
-        ["1.123:1.123", "1"],
-        ["11.123:11.123", "1"]
+        ["1:1"],
+        ["1.1:1"],
+        ["1.12:1"],
+        ["1.123:1"],
+        ["1:1.1"],
+        ["1:1.12"],
+        ["1.1:1.1"],
+        ["1.123:1.123"],
+        ["11.123:11.123"]
       ].forEach(([validAR, validArDecimal]) =>
         testValidAR({
           ar: validAR,
-          arDecimal: validArDecimal
         })
       );
     });
 
     describe("invalid AR", () => {
       const testInvalidAR = ar => {
-        it(`height should not be set when an invalid aspectRatio (${ar}) is passed`, () => {
+        it(`an invalid ar prop (${ar}) will still generate an ar query parameter`, () => {
           const oldConsole = global.console;
           global.console = { warn: jest.fn() };
 
           const parseParam = (url, param) => {
             const matched = url.match("[?&]" + param + "=([^&]+)");
             if (!matched) return undefined;
-            return parseInt(matched[1], 10);
+            return matched[1];
           };
           const removeFallbackSrcSet = srcSets => srcSets.slice(0, -1);
 
@@ -701,10 +697,10 @@ describe("When using the component", () => {
           const srcSetUrls = srcSets.map(srcSet => srcSet.split(" ")[0]);
           removeFallbackSrcSet(srcSetUrls).forEach(srcSetUrl => {
             const w = parseParam(srcSetUrl, "w");
-            const h = parseParam(srcSetUrl, "h");
-
+            const ar = parseParam(srcSetUrl, "ar");
+            
             expect(w).toBeTruthy();
-            expect(h).toBeFalsy();
+            expect(ar).toBeTruthy();
           });
 
           global.console = oldConsole;
@@ -723,7 +719,7 @@ describe("When using the component", () => {
       ].forEach(invalidAR => testInvalidAR(invalidAR));
     });
 
-    it("srcsets should not have a height set when aspectRatio is not set", () => {
+    it("srcsets should not have an ar parameter when aspectRatio is not set", () => {
       sut = shallow(
         <Imgix
           src={src}
@@ -736,15 +732,15 @@ describe("When using the component", () => {
       const parseParam = (str, param) => {
         const matched = str.match("[?&]" + param + "=([^&]+)");
         if (!matched) return null;
-        return parseInt(matched[1], 10);
+        return matched[1];
       };
       srcSetUrls.forEach(srcSetUrl => {
-        const h = parseParam(srcSetUrl, "h");
-        expect(h).toBeFalsy();
+        const ar = parseParam(srcSetUrl, "ar");
+        expect(ar).toBeFalsy();
       });
     });
 
-    it("the generated src should not have ar included", () => {
+    it("the generated src should have an ar parameter included", () => {
       sut = shallow(
         <Imgix
           src={src}
@@ -753,7 +749,7 @@ describe("When using the component", () => {
         />
       );
 
-      expectSrcsTo(sut, expect.not.stringContaining("ar="));
+      expectSrcsTo(sut, expect.stringContaining("ar="));
     });
   });
 


### PR DESCRIPTION
This PR refactors how the `ReactImgix` component determines an image's aspect ratio, now using the [imgix aspect ratio parameter](https://blog.imgix.com/2019/07/17/aspect-ratio-parameter-makes-cropping-even-easier) `ar=` instead of appending a calculated height `h=` value based on the prop. This should yield overall better performance, code cleanliness, and bring the component more in line with the imgix API.

---------
**Demo**
Given the same component invocation, the URL constructed will be different but still render the same image.
```jsx
<Imgix
	src="http://domain.imgix.net/image.jpg"
	imgixParams={{ ar: "2:1" }}
/>
```

|        | Example srcset URL                                        |
|--------|-----------------------------------------------------------|
| Before | http://domain.imgix.net/image.jpg?...&h=50&w=100          |
| After  | http://domain.imgix.net/image.jpg?...&ar=2%3A1&w=100      |
