### PR TITLE
chore: refactored from findDOMNode to refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)",
     "Max Kolyanov (https://github.com/maxkolyanov)",
     "Sherwin Heydarbeygi <sherwin@imgix.com> (https://github.com/sherwinski)",
-    "Baldur Helgason <baldur.helgason@gmail.com> (https://github.com/baldurh)"
+    "Baldur Helgason <baldur.helgason@gmail.com> (https://github.com/baldurh)",
+    "Tanner Stirrat <tstirrat@gmail.com> (https://github.com/tstirrat15)"
   ],
   "license": "ISC",
   "bugs": {

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -322,7 +322,7 @@ class PictureImpl extends Component {
       _children.push(_children.splice(imgIdx, 1)[0]);
     }
 
-      return <picture ref={el => (this.pictureRef = el)} children={_children} />;
+    return <picture ref={el => (this.pictureRef = el)} children={_children} />;
   }
 }
 PictureImpl.displayName = "ReactImgixPicture";

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -1,6 +1,6 @@
 import "./array-findindex";
 
-import React, { Component, createRef } from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 
 import targetWidths from "./targetWidths";
@@ -193,11 +193,11 @@ class ReactImgix extends Component {
 
   constructor(props) {
     super(props);
-    this.imgRef = createRef();
+    this.imgRef = null;
   }
 
   componentDidMount() {
-    this.props.onMounted(this.imgRef.current);
+    this.props.onMounted(this.imgRef);
   };
 
   render() {
@@ -237,7 +237,7 @@ class ReactImgix extends Component {
       width: width <= 1 ? null : width,
       height: height <= 1 ? null : height,
       [attributeConfig.src]: src,
-      ref: this.imgRef,
+      ref: el => (this.imgRef = el),
     });
     if (!disableSrcSet) {
       childProps[attributeConfig.srcSet] = srcSet;
@@ -280,11 +280,11 @@ class PictureImpl extends Component {
 
   constructor(props) {
     super(props);
-    this.pictureRef = createRef();
+    this.pictureRef = null;
   }
 
   componentDidMount() {
-    this.props.onMounted(this.pictureRef.current);
+    this.props.onMounted(this.pictureRef);
   };
 
   render() {
@@ -322,7 +322,7 @@ class PictureImpl extends Component {
       _children.push(_children.splice(imgIdx, 1)[0]);
     }
 
-    return <picture ref={this.pictureRef} children={_children} />;
+      return <picture ref={el => (this.pictureRef = el)} children={_children} />;
   }
 }
 PictureImpl.displayName = "ReactImgixPicture";
@@ -339,11 +339,11 @@ class SourceImpl extends Component {
 
   constructor(props) {
     super(props);
-    this.sourceRef = createRef();
+    this.sourceRef = null;
   }
 
   componentDidMount() {
-    this.props.onMounted(this.sourceRef.current);
+    this.props.onMounted(this.sourceRef);
   };
 
   render() {
@@ -368,7 +368,7 @@ class SourceImpl extends Component {
       className: this.props.className,
       width: width <= 1 ? null : width,
       height: height <= 1 ? null : height,
-      ref: this.sourceRef,
+      ref: el => (this.sourceRef = el),
     });
 
     // inside of a <picture> element a <source> element ignores its src

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -198,7 +198,7 @@ class ReactImgix extends Component {
 
   componentDidMount() {
     this.props.onMounted(this.imgRef);
-  };
+  }
 
   render() {
     const { disableSrcSet, type, width, height } = this.props;
@@ -237,7 +237,7 @@ class ReactImgix extends Component {
       width: width <= 1 ? null : width,
       height: height <= 1 ? null : height,
       [attributeConfig.src]: src,
-      ref: el => (this.imgRef = el),
+      ref: el => (this.imgRef = el)
     });
     if (!disableSrcSet) {
       childProps[attributeConfig.srcSet] = srcSet;
@@ -285,7 +285,7 @@ class PictureImpl extends Component {
 
   componentDidMount() {
     this.props.onMounted(this.pictureRef);
-  };
+  }
 
   render() {
     const { children } = this.props;
@@ -344,7 +344,7 @@ class SourceImpl extends Component {
 
   componentDidMount() {
     this.props.onMounted(this.sourceRef);
-  };
+  }
 
   render() {
     const { disableSrcSet, width, height } = this.props;
@@ -354,21 +354,21 @@ class SourceImpl extends Component {
     const { src, srcSet } = buildSrc(
       Object.assign({}, this.props, {
         type: "source",
-        imgixParams: imgixParams(this.props),
+        imgixParams: imgixParams(this.props)
       })
     );
 
     const attributeConfig = Object.assign(
       {},
       defaultAttributeMap,
-      this.props.attributeConfig,
+      this.props.attributeConfig
     );
     const childProps = Object.assign({}, this.props.htmlAttributes, {
       [attributeConfig.sizes]: this.props.sizes,
       className: this.props.className,
       width: width <= 1 ? null : width,
       height: height <= 1 ? null : height,
-      ref: el => (this.sourceRef = el),
+      ref: el => (this.sourceRef = el)
     });
 
     // inside of a <picture> element a <source> element ignores its src

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -1,7 +1,6 @@
 import "./array-findindex";
 
-import ReactDOM from "react-dom";
-import React, { Component } from "react";
+import React, { Component, createRef } from "react";
 import PropTypes from "prop-types";
 
 import targetWidths from "./targetWidths";
@@ -192,9 +191,13 @@ class ReactImgix extends Component {
     onMounted: noop
   };
 
-  componentDidMount = () => {
-    const node = ReactDOM.findDOMNode(this);
-    this.props.onMounted(node);
+  constructor(props) {
+    super(props);
+    this.imgRef = createRef();
+  }
+
+  componentDidMount() {
+    this.props.onMounted(this.imgRef.current);
   };
 
   render() {
@@ -233,7 +236,8 @@ class ReactImgix extends Component {
       className: this.props.className,
       width: width <= 1 ? null : width,
       height: height <= 1 ? null : height,
-      [attributeConfig.src]: src
+      [attributeConfig.src]: src,
+      ref: this.imgRef,
     });
     if (!disableSrcSet) {
       childProps[attributeConfig.srcSet] = srcSet;
@@ -274,10 +278,15 @@ class PictureImpl extends Component {
     onMounted: noop
   };
 
-  componentDidMount = () => {
-    const node = ReactDOM.findDOMNode(this);
-    this.props.onMounted(node);
+  constructor(props) {
+    super(props);
+    this.pictureRef = createRef();
+  }
+
+  componentDidMount() {
+    this.props.onMounted(this.pictureRef.current);
   };
+
   render() {
     const { children } = this.props;
 
@@ -291,10 +300,10 @@ class PictureImpl extends Component {
       ) || [];
 
     /*
-		We need to make sure an <img /> or <Imgix /> is the last child so we look for one in children
-		  a. if we find one, move it to the last entry if it's not already there
-		  b. if we don't find one, warn the user as they probably want to pass one.
-		*/
+    We need to make sure an <img /> or <Imgix /> is the last child so we look for one in children
+      a. if we find one, move it to the last entry if it's not already there
+      b. if we don't find one, warn the user as they probably want to pass one.
+    */
 
     // look for an <img> or <ReactImgix type='img'> - at the bare minimum we have to have a single <img> element or else it will not work.
     let imgIdx = _children.findIndex(
@@ -313,7 +322,7 @@ class PictureImpl extends Component {
       _children.push(_children.splice(imgIdx, 1)[0]);
     }
 
-    return <picture children={_children} />;
+    return <picture ref={this.pictureRef} children={_children} />;
   }
 }
 PictureImpl.displayName = "ReactImgixPicture";
@@ -328,10 +337,15 @@ class SourceImpl extends Component {
     onMounted: noop
   };
 
-  componentDidMount = () => {
-    const node = ReactDOM.findDOMNode(this);
-    this.props.onMounted(node);
+  constructor(props) {
+    super(props);
+    this.sourceRef = createRef();
+  }
+
+  componentDidMount() {
+    this.props.onMounted(this.sourceRef.current);
   };
+
   render() {
     const { disableSrcSet, width, height } = this.props;
 
@@ -340,20 +354,21 @@ class SourceImpl extends Component {
     const { src, srcSet } = buildSrc(
       Object.assign({}, this.props, {
         type: "source",
-        imgixParams: imgixParams(this.props)
+        imgixParams: imgixParams(this.props),
       })
     );
 
     const attributeConfig = Object.assign(
       {},
       defaultAttributeMap,
-      this.props.attributeConfig
+      this.props.attributeConfig,
     );
     const childProps = Object.assign({}, this.props.htmlAttributes, {
       [attributeConfig.sizes]: this.props.sizes,
       className: this.props.className,
       width: width <= 1 ? null : width,
-      height: height <= 1 ? null : height
+      height: height <= 1 ? null : height,
+      ref: this.sourceRef,
     });
 
     // inside of a <picture> element a <source> element ignores its src

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -1,6 +1,5 @@
 import sinon from "sinon";
 import React from "react";
-import ReactDOM from "react-dom";
 import { shallow as enzymeShallow, mount } from "enzyme";
 import PropTypes from "prop-types";
 import { shallowUntilTarget } from "../helpers";
@@ -29,28 +28,6 @@ const src = "http://domain.imgix.net/image.jpg";
 let sut, vdom, instance;
 const EMPTY_IMAGE_SRC =
   "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=";
-
-async function renderImageAndBreakInStages({
-  element,
-  mockImage = <img />,
-  afterFirstRender = async () => {},
-  afterSecondRender = async () => {}
-}) {
-  sinon.stub(ReactDOM, "findDOMNode").callsFake(() => mockImage);
-
-  const sut = shallow(element);
-
-  await afterFirstRender(sut);
-
-  await sut.instance().componentDidMount();
-  sut.update();
-
-  await afterSecondRender(sut);
-
-  ReactDOM.findDOMNode.restore();
-
-  return sut;
-}
 
 let oldConsole, log;
 beforeEach(() => {
@@ -182,23 +159,18 @@ describe("When in default mode", () => {
 
 describe("When in image mode", () => {
   it("a callback passed through the onMounted prop should be called", () => {
-    const mockImage = <img />;
-    sinon.stub(ReactDOM, "findDOMNode").callsFake(() => mockImage);
-
     const onMountedSpy = sinon.spy();
-    sut = shallow(
+    const sut = mount(
       <Imgix
         src={"https://mysource.imgix.net/demo.png"}
         sizes="100vw"
         onMounted={onMountedSpy}
       />,
-      __ReactImgixImpl,
-      {}
     );
 
-    sinon.assert.calledWith(onMountedSpy, mockImage);
-
-    ReactDOM.findDOMNode.restore();
+    expect(onMountedSpy.callCount).toEqual(1);
+    const onMountArg = onMountedSpy.lastCall.args[0];
+    expect(onMountArg).toBeInstanceOf(HTMLImageElement);
   });
 });
 
@@ -326,23 +298,18 @@ describe("When in <source> mode", () => {
     });
   });
   it("a callback passed through the onMounted prop should be called", () => {
-    const mockImage = <source />;
-    sinon.stub(ReactDOM, "findDOMNode").callsFake(() => mockImage);
-
     const onMountedSpy = sinon.spy();
-    sut = shallow(
+    const sut = mount(
       <Source
         src={"https://mysource.imgix.net/demo.png"}
         sizes="100vw"
         onMounted={onMountedSpy}
-      />,
-      __SourceImpl,
-      {}
+      />
     );
 
-    sinon.assert.calledWith(onMountedSpy, mockImage);
-
-    ReactDOM.findDOMNode.restore();
+    expect(onMountedSpy.callCount).toEqual(1);
+    const onMountArg = onMountedSpy.lastCall.args[0];
+    expect(onMountArg).toBeInstanceOf(HTMLSourceElement);
   });
 });
 
@@ -460,21 +427,16 @@ describe("When in picture mode", () => {
   });
 
   it("a callback passed through the onMounted prop should be called", () => {
-    const mockImage = <source />;
-    sinon.stub(ReactDOM, "findDOMNode").callsFake(() => mockImage);
-
     const onMountedSpy = sinon.spy();
-    sut = shallow(
-      <Picture onMounted={onMountedSpy}>
+    sut = mount(
+      <Picture onMounted={onMountedSpy} foo={1}>
         <img />
       </Picture>,
-      __PictureImpl,
-      {}
     );
 
-    sinon.assert.calledWith(onMountedSpy, mockImage);
-
-    ReactDOM.findDOMNode.restore();
+    expect(onMountedSpy.callCount).toEqual(1);
+    const onMountArg = onMountedSpy.lastCall.args[0];
+    expect(onMountArg).toBeInstanceOf(HTMLPictureElement);
   });
 });
 

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -165,7 +165,7 @@ describe("When in image mode", () => {
         src={"https://mysource.imgix.net/demo.png"}
         sizes="100vw"
         onMounted={onMountedSpy}
-      />,
+      />
     );
 
     expect(onMountedSpy.callCount).toEqual(1);
@@ -431,7 +431,7 @@ describe("When in picture mode", () => {
     sut = mount(
       <Picture onMounted={onMountedSpy} foo={1}>
         <img />
-      </Picture>,
+      </Picture>
     );
 
     expect(onMountedSpy.callCount).toEqual(1);


### PR DESCRIPTION
Fixes #475 

##  Description
`findDOMNode` is deprecated in `StrictMode`. It's recommended against [in the official docs](https://reactjs.org/docs/react-dom.html#finddomnode), and if the functionality that it enables is required, `ref`s are a good way of addressing the problem.

This PR refactors away from `findDOMNode` towards `ref`s.

## Changes
* Refactor `react-imgix` components to use `ref`s in favor of `findDOMNode`
* Refactor tests to use `mount` instead of `shallow`, since `shallow` doesn't create or use `ref`s
* Remove a test function that wasn't in use

## Steps to Test

See that the refactored tests are sane and passing.

## Note

I wasn't quite sure what sort of work this represented (fix/feature/chore). Please let me know if a different designation is more appropriate.