### PR TITLE
fix: remove default fit parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ This will generate HTML similar to the following:
 
 ```html
 <img
-  src="https://assets.imgix.net/examples/pione.jpg?auto=format&amp;crop=faces&amp;fit=crop&amp;ixlib=react-7.2.0"
+  src="https://assets.imgix.net/examples/pione.jpg?auto=format&amp;crop=faces&amp;ixlib=react-7.2.0"
   sizes="100vw"
   srcset="
-    https://assets.imgix.net/examples/pione.jpg?auto=format&amp;crop=faces&amp;fit=crop&amp;ixlib=react-7.2.0&amp;w=100 100w,
-    https://assets.imgix.net/examples/pione.jpg?auto=format&amp;crop=faces&amp;fit=crop&amp;ixlib=react-7.2.0&amp;w=200 200w,
+    https://assets.imgix.net/examples/pione.jpg?auto=format&amp;crop=faces&amp;ixlib=react-7.2.0&amp;w=100 100w,
+    https://assets.imgix.net/examples/pione.jpg?auto=format&amp;crop=faces&amp;ixlib=react-7.2.0&amp;w=200 200w,
     ...
   "
 />
@@ -99,8 +99,6 @@ import Imgix from "react-imgix";
   height={200}
 />;
 ```
-
-NB: Since this library sets [`fit`](https://docs.imgix.com/apis/url/size/fit) to `crop` by default, when just a width or height is set, the image will resize and maintain aspect ratio. When both are set, the image will be cropped to that size, maintaining pixel aspect ratio (i.e. edges are clipped in order to not stretch the photo). If this isn't desired, set `fit` to be another value (e.g. `clip`)
 
 [![Edit xp0348lv0z](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/charming-keller-kjnsq)
 

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -17,8 +17,7 @@ const NODE_ENV = process.env.NODE_ENV;
 const buildKey = idx => `react-imgix-${idx}`;
 
 const defaultImgixParams = {
-  auto: ["format"],
-  fit: "crop"
+  auto: ["format"]
 };
 
 const defaultAttributeMap = {
@@ -170,12 +169,7 @@ function buildSrc({
  */
 function imgixParams(props) {
   const params = Object.assign({}, defaultImgixParams, props.imgixParams);
-
-  let fit = false;
-  if (params.crop != null) fit = "crop";
-  if (params.fit) fit = params.fit;
-
-  return Object.assign({}, params, { fit });
+  return Object.assign({}, params);
 }
 
 /**

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -456,16 +456,11 @@ describe("When using the component", () => {
   it("the rendered element should contain the class name provided", () => {
     expect(sut.props().className).toContain(className);
   });
-  it("the crop param should alter the crop and fit query parameters correctly", () => {
-    sut = shallow(
-      <Imgix src={src} sizes="100vw" imgixParams={{ crop: "faces,entropy" }} />
-    );
-
-    expectSrcsToContain(sut, "crop=faces%2Centropy");
-    expectSrcsToContain(sut, "fit=crop");
-  });
   it("the fit param should alter the fit query pararmeter correctly", () => {
-    expectSrcsToContain(sut, "fit=crop");
+    expectSrcsTo(
+      sut,
+      expect.not.stringContaining("fit=crop")
+    );
   });
   it("the keys of custom url parameters should be url encoded", () => {
     const helloWorldKey = "hello world";

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -457,10 +457,7 @@ describe("When using the component", () => {
     expect(sut.props().className).toContain(className);
   });
   it("the fit param should alter the fit query pararmeter correctly", () => {
-    expectSrcsTo(
-      sut,
-      expect.not.stringContaining("fit=crop")
-    );
+    expectSrcsTo(sut, expect.not.stringContaining("fit=crop"));
   });
   it("the keys of custom url parameters should be url encoded", () => {
     const helloWorldKey = "hello world";


### PR DESCRIPTION
This PR removes the default `fit=crop` parameter from the ReactImgix component when building `src` and `srcset` attributes. This change will take effect in the next major release of react-imgix (v9.0.0).

**Background:** After some confusion arose regarding the differences between this project and imgix's API, we have decided it is best to remove `fit=crop` as a default parameter. This will realign the component behavior to match that of imgix's service in a way that users would expect when transitioning to this library.

The main difference this will yield for users is that they will now have to manually pass in the `fit=crop` parameter if so desired:

```jsx
<Imgix
	src="https://assets.imgix.net/examples/pione.jpg"
    sizes="100vw"
    imgixParams={{ fit: "crop" }}
/>
```

Resolves #446 