### PR TITLE
fix: prevent overwriting htmlAttributes.ref

### DIFF
--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -220,20 +220,34 @@ class ReactImgix extends Component {
       defaultAttributeMap,
       this.props.attributeConfig
     );
-    const childProps = Object.assign(
-      {},
-      {
-        [attributeConfig.sizes]: this.props.sizes,
-        className: this.props.className,
-        width: width <= 1 ? null : width,
-        height: height <= 1 ? null : height,
-        [attributeConfig.src]: src,
-        ref: el => {
-          this.imgRef = el;
+    const setParentRef = ref => {
+      if (!ref) {
+        return;
+      }
+
+      // assign ref based on if it's a callback vs object
+      if (typeof ref === "function") {
+        ref(this.imgRef);
+      } else {
+        ref.current = this.imgRef;
+      }
+    };
+    const childProps = Object.assign({}, this.props.htmlAttributes, {
+      [attributeConfig.sizes]: this.props.sizes,
+      className: this.props.className,
+      width: width <= 1 ? null : width,
+      height: height <= 1 ? null : height,
+      [attributeConfig.src]: src,
+      ref: el => {
+        this.imgRef = el;
+        if (
+          this.props.htmlAttributes !== undefined &&
+          "ref" in this.props.htmlAttributes
+        ) {
+          setParentRef(this.props.htmlAttributes.ref);
         }
-      },
-      this.props.htmlAttributes
-    );
+      }
+    });
     if (!disableSrcSet) {
       childProps[attributeConfig.srcSet] = srcSet;
     }
@@ -337,17 +351,33 @@ class SourceImpl extends Component {
       defaultAttributeMap,
       this.props.attributeConfig
     );
-    const childProps = Object.assign(
-      {},
-      {
-        [attributeConfig.sizes]: this.props.sizes,
-        className: this.props.className,
-        width: width <= 1 ? null : width,
-        height: height <= 1 ? null : height,
-        ref: el => (this.sourceRef = el)
-      },
-      this.props.htmlAttributes
-    );
+    const setParentRef = ref => {
+      if (!ref) {
+        return;
+      }
+
+      // assign ref based on if it's a callback vs object
+      if (typeof ref === "function") {
+        ref(this.sourceRef);
+      } else {
+        ref.current = this.sourceRef;
+      }
+    };
+    const childProps = Object.assign({}, this.props.htmlAttributes, {
+      [attributeConfig.sizes]: this.props.sizes,
+      className: this.props.className,
+      width: width <= 1 ? null : width,
+      height: height <= 1 ? null : height,
+      ref: el => {
+        this.sourceRef = el;
+        if (
+          this.props.htmlAttributes !== undefined &&
+          "ref" in this.props.htmlAttributes
+        ) {
+          setParentRef(this.props.htmlAttributes.ref);
+        }
+      }
+    });
 
     // inside of a <picture> element a <source> element ignores its src
     // attribute in favor of srcSet so we set that with either an actual

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -60,6 +60,19 @@ function aspectRatioIsValid(aspectRatio) {
   return /^\d+(\.\d+)?:\d+(\.\d+)?$/.test(aspectRatio);
 }
 
+const setParentRef = (parentRef, el) =>{
+  if (!parentRef) {
+    return;
+  }
+
+  // assign ref based on if it's a callback vs object
+  if (typeof parentRef === "function") {
+    parentRef(el);
+  } else {
+    parentRef.current = el;
+  }
+}
+
 const buildSrcSetPairWithFixedHeight = (url, targetWidth, fixedHeight, _) =>
   url + "&h=" + fixedHeight + "&w=" + targetWidth + " " + targetWidth + "w";
 
@@ -220,18 +233,6 @@ class ReactImgix extends Component {
       defaultAttributeMap,
       this.props.attributeConfig
     );
-    const setParentRef = ref => {
-      if (!ref) {
-        return;
-      }
-
-      // assign ref based on if it's a callback vs object
-      if (typeof ref === "function") {
-        ref(this.imgRef);
-      } else {
-        ref.current = this.imgRef;
-      }
-    };
     const childProps = Object.assign({}, this.props.htmlAttributes, {
       [attributeConfig.sizes]: this.props.sizes,
       className: this.props.className,
@@ -244,7 +245,7 @@ class ReactImgix extends Component {
           this.props.htmlAttributes !== undefined &&
           "ref" in this.props.htmlAttributes
         ) {
-          setParentRef(this.props.htmlAttributes.ref);
+          setParentRef(this.props.htmlAttributes.ref, this.imgRef);
         }
       }
     });
@@ -351,18 +352,6 @@ class SourceImpl extends Component {
       defaultAttributeMap,
       this.props.attributeConfig
     );
-    const setParentRef = ref => {
-      if (!ref) {
-        return;
-      }
-
-      // assign ref based on if it's a callback vs object
-      if (typeof ref === "function") {
-        ref(this.sourceRef);
-      } else {
-        ref.current = this.sourceRef;
-      }
-    };
     const childProps = Object.assign({}, this.props.htmlAttributes, {
       [attributeConfig.sizes]: this.props.sizes,
       className: this.props.className,
@@ -374,7 +363,7 @@ class SourceImpl extends Component {
           this.props.htmlAttributes !== undefined &&
           "ref" in this.props.htmlAttributes
         ) {
-          setParentRef(this.props.htmlAttributes.ref);
+          setParentRef(this.props.htmlAttributes.ref, this.sourceRef);
         }
       }
     });

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -220,14 +220,20 @@ class ReactImgix extends Component {
       defaultAttributeMap,
       this.props.attributeConfig
     );
-    const childProps = Object.assign({}, this.props.htmlAttributes, {
-      [attributeConfig.sizes]: this.props.sizes,
-      className: this.props.className,
-      width: width <= 1 ? null : width,
-      height: height <= 1 ? null : height,
-      [attributeConfig.src]: src,
-      ref: el => (this.imgRef = el)
-    });
+    const childProps = Object.assign(
+      {},
+      {
+        [attributeConfig.sizes]: this.props.sizes,
+        className: this.props.className,
+        width: width <= 1 ? null : width,
+        height: height <= 1 ? null : height,
+        [attributeConfig.src]: src,
+        ref: el => {
+          this.imgRef = el;
+        }
+      },
+      this.props.htmlAttributes
+    );
     if (!disableSrcSet) {
       childProps[attributeConfig.srcSet] = srcSet;
     }
@@ -331,13 +337,17 @@ class SourceImpl extends Component {
       defaultAttributeMap,
       this.props.attributeConfig
     );
-    const childProps = Object.assign({}, this.props.htmlAttributes, {
-      [attributeConfig.sizes]: this.props.sizes,
-      className: this.props.className,
-      width: width <= 1 ? null : width,
-      height: height <= 1 ? null : height,
-      ref: el => (this.sourceRef = el)
-    });
+    const childProps = Object.assign(
+      {},
+      {
+        [attributeConfig.sizes]: this.props.sizes,
+        className: this.props.className,
+        width: width <= 1 ? null : width,
+        height: height <= 1 ? null : height,
+        ref: el => (this.sourceRef = el)
+      },
+      this.props.htmlAttributes
+    );
 
     // inside of a <picture> element a <source> element ignores its src
     // attribute in favor of srcSet so we set that with either an actual

--- a/test/unit/helpers/shallowUntilTarget.test.jsx
+++ b/test/unit/helpers/shallowUntilTarget.test.jsx
@@ -55,10 +55,7 @@ describe("helpers", () => {
     });
 
     it("lets you unwrap a component two levels", () => {
-      const Example = compose(
-        wrapper(),
-        wrapper()
-      )(ExampleBase);
+      const Example = compose(wrapper(), wrapper())(ExampleBase);
 
       const root = shallowUntilTarget(<Example />, ExampleBase);
       expect(root.text()).toEqual("Example component");
@@ -84,11 +81,7 @@ describe("helpers", () => {
     });
 
     it("gives up trying to unwrap component after maxTries", () => {
-      const Example = compose(
-        wrapper(),
-        wrapper(),
-        wrapper()
-      )(ExampleBase);
+      const Example = compose(wrapper(), wrapper(), wrapper())(ExampleBase);
 
       expect(() => {
         shallowUntilTarget(<Example />, ExampleBase, {

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -355,7 +355,6 @@ describe("When in <source> mode", () => {
         />
       );
 
-      expect(callback.called).toBeTruthy();
       expect(callback.callCount).toEqual(1);
     });
 
@@ -372,9 +371,7 @@ describe("When in <source> mode", () => {
         />
       );
 
-      expect(htmlAttrCallback.called).toBeTruthy();
       expect(htmlAttrCallback.callCount).toEqual(1);
-      expect(onMountedCallback.called).toBeTruthy();
       expect(onMountedCallback.callCount).toEqual(1);
     });
   });
@@ -816,7 +813,6 @@ describe("When using the component", () => {
         />
       );
 
-      expect(callback.called).toBeTruthy();
       expect(callback.callCount).toEqual(1);
     });
 
@@ -833,9 +829,7 @@ describe("When using the component", () => {
         />
       );
 
-      expect(htmlAttrCallback.called).toBeTruthy();
       expect(htmlAttrCallback.callCount).toEqual(1);
-      expect(onMountedCallback.called).toBeTruthy();
       expect(onMountedCallback.callCount).toEqual(1);
     });
   });

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -166,7 +166,6 @@ describe("When in image mode", () => {
       />
     );
 
-    expect(onMountedSpy.called);
     expect(onMountedSpy.callCount).toEqual(1);
     const onMountArg = onMountedSpy.lastCall.args[0];
     expect(onMountArg).toBeInstanceOf(HTMLImageElement);
@@ -358,6 +357,25 @@ describe("When in <source> mode", () => {
 
       expect(callback.called).toBeTruthy();
       expect(callback.callCount).toEqual(1);
+    });
+
+    it("stills calls onMounted if a ref is passed via htmlAttributes", () => {
+      const htmlAttrCallback = sinon.spy();
+      const onMountedCallback = sinon.spy();
+
+      sut = mount(
+        <Source
+          src={"https://mysource.imgix.net/demo.png"}
+          sizes="100vw"
+          onMounted={onMountedCallback}
+          htmlAttributes={{ ref: htmlAttrCallback }}
+        />
+      );
+
+      expect(htmlAttrCallback.called).toBeTruthy();
+      expect(htmlAttrCallback.callCount).toEqual(1);
+      expect(onMountedCallback.called).toBeTruthy();
+      expect(onMountedCallback.callCount).toEqual(1);
     });
   });
 });
@@ -800,6 +818,25 @@ describe("When using the component", () => {
 
       expect(callback.called).toBeTruthy();
       expect(callback.callCount).toEqual(1);
+    });
+
+    it("stills calls onMounted if a ref is passed via htmlAttributes", () => {
+      const htmlAttrCallback = sinon.spy();
+      const onMountedCallback = sinon.spy();
+
+      sut = mount(
+        <Imgix
+          src={"https://mysource.imgix.net/demo.png"}
+          sizes="100vw"
+          onMounted={onMountedCallback}
+          htmlAttributes={{ ref: htmlAttrCallback }}
+        />
+      );
+
+      expect(htmlAttrCallback.called).toBeTruthy();
+      expect(htmlAttrCallback.callCount).toEqual(1);
+      expect(onMountedCallback.called).toBeTruthy();
+      expect(onMountedCallback.callCount).toEqual(1);
     });
   });
 

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -166,6 +166,7 @@ describe("When in image mode", () => {
       />
     );
 
+    expect(onMountedSpy.called);
     expect(onMountedSpy.callCount).toEqual(1);
     const onMountArg = onMountedSpy.lastCall.args[0];
     expect(onMountArg).toBeInstanceOf(HTMLImageElement);
@@ -308,6 +309,56 @@ describe("When in <source> mode", () => {
     expect(onMountedSpy.callCount).toEqual(1);
     const onMountArg = onMountedSpy.lastCall.args[0];
     expect(onMountArg).toBeInstanceOf(HTMLSourceElement);
+  });
+
+  describe("using the htmlAttributes prop", () => {
+    it("assigns an alt attribute given htmlAttributes.alt", async () => {
+      const htmlAttributes = {
+        alt: "Example alt attribute"
+      };
+
+      sut = mount(
+        <Source
+          src={"https://mysource.imgix.net/demo.png"}
+          sizes="100vw"
+          htmlAttributes={htmlAttributes}
+        />
+      );
+
+      expect(sut.props()["htmlAttributes"].alt).toEqual(htmlAttributes.alt);
+    });
+
+    it("passes any attributes via htmlAttributes to the rendered element", () => {
+      const htmlAttributes = {
+        "data-src": "https://mysource.imgix.net/demo.png"
+      };
+      sut = mount(
+        <Source
+          src={"https://mysource.imgix.net/demo.png"}
+          sizes="100vw"
+          htmlAttributes={htmlAttributes}
+        />
+      );
+
+      expect(sut.props()["htmlAttributes"]["data-src"]).toEqual(
+        htmlAttributes["data-src"]
+      );
+    });
+
+    it("attaches a ref via htmlAttributes", () => {
+      const callback = sinon.spy();
+
+      sut = mount(
+        <Source
+          src={"https://mysource.imgix.net/demo.png"}
+          sizes="100vw"
+          htmlAttributes={{ ref: callback }}
+        />
+      );
+
+      expect(callback.called).toBeTruthy();
+      expect(callback.callCount).toEqual(1);
+    });
   });
 });
 
@@ -706,33 +757,50 @@ describe("When using the component", () => {
     });
   });
 
-  it("an alt attribute should be set given htmlAttributes.alt", async () => {
-    const htmlAttributes = {
-      alt: "Example alt attribute"
-    };
-    sut = shallow(
-      <Imgix
-        src={"https://mysource.imgix.net/demo.png"}
-        sizes="100vw"
-        htmlAttributes={htmlAttributes}
-      />
-    );
-    expect(sut.props().alt).toEqual(htmlAttributes.alt);
-  });
+  describe("using the htmlAttributes prop", () => {
+    it("assigns an alt attribute given htmlAttributes.alt", async () => {
+      const htmlAttributes = {
+        alt: "Example alt attribute"
+      };
+      sut = shallow(
+        <Imgix
+          src={"https://mysource.imgix.net/demo.png"}
+          sizes="100vw"
+          htmlAttributes={htmlAttributes}
+        />
+      );
+      expect(sut.props().alt).toEqual(htmlAttributes.alt);
+    });
 
-  it("any attributes passed via htmlAttributes should be added to the rendered element", () => {
-    const htmlAttributes = {
-      "data-src": "https://mysource.imgix.net/demo.png"
-    };
-    sut = shallow(
-      <Imgix
-        src={"https://mysource.imgix.net/demo.png"}
-        sizes="100vw"
-        htmlAttributes={htmlAttributes}
-      />
-    );
+    it("passes any attributes via htmlAttributes to the rendered element", () => {
+      const htmlAttributes = {
+        "data-src": "https://mysource.imgix.net/demo.png"
+      };
+      sut = shallow(
+        <Imgix
+          src={"https://mysource.imgix.net/demo.png"}
+          sizes="100vw"
+          htmlAttributes={htmlAttributes}
+        />
+      );
 
-    expect(sut.props()["data-src"]).toEqual(htmlAttributes["data-src"]);
+      expect(sut.props()["data-src"]).toEqual(htmlAttributes["data-src"]);
+    });
+
+    it("attaches a ref via htmlAttributes", () => {
+      const callback = sinon.spy();
+
+      sut = mount(
+        <Imgix
+          src={"https://mysource.imgix.net/demo.png"}
+          sizes="100vw"
+          htmlAttributes={{ ref: callback }}
+        />
+      );
+
+      expect(callback.called).toBeTruthy();
+      expect(callback.callCount).toEqual(1);
+    });
   });
 
   it("an ixlib parameter should be included by default in the computed src and srcSet", () => {


### PR DESCRIPTION
Fixes #494 
Refactoring work completed in #475 inadvertently introduced a regression where we are overwriting a `ref` passed via `htmlAttributes`. This PR better handles this situation while accounting for refs that are either passed as a callback or an object.