### PR TITLE
docs: fix broken link to contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A [React](https://facebook.github.io/react/) component that renders images using
   - [Warnings](#warnings)
 - [Browser Support](#browser-support)
 - [Upgrade Guides](#upgrade-guides)
-- [Contributors](#contributors-✨)
+- [Contributors](#contributors-)
 - [Meta](#meta)
 
 ## Overview / Resources


### PR DESCRIPTION
Fixes a broken link to the [Contributors section](https://github.com/imgix/react-imgix#contributors-) in the table of contents. Apparently `✨`s aren't cool enough for markdown or something.