### PR TITLE
docs: fix broken contributors link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
   - [8.x to 9.0](#8x-to-90)
   - [7.x to 8.0](#7x-to-80)
 - [Browser Support](#browser-support)
-- [Contributors ✨](#contributors-%e2%9c%a8)
+- [Contributors ✨](#contributors-)
 - [Meta](#meta)
 
 ## Overview / Resources


### PR DESCRIPTION
This PR fixes #564 

When tested locally the contributors link in the README TOC only works when referenced as `#contributors-%e2%9c%a8` - this was created automatically by a vs code extension that I use. However, GitHub markdown won't work in the same way unless the encoded bit is excluded.