### PR TITLE
fix(background): fortify `hasDOMDimensions` check for null height

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "Max Kolyanov (https://github.com/maxkolyanov)",
     "Sherwin Heydarbeygi <sherwin@imgix.com> (https://github.com/sherwinski)",
     "Baldur Helgason <baldur.helgason@gmail.com> (https://github.com/baldurh)",
-    "Tanner Stirrat <tstirrat@gmail.com> (https://github.com/tstirrat15)"
+    "Tanner Stirrat <tstirrat@gmail.com> (https://github.com/tstirrat15)",
+    "Stephen Cook <stephen@stephencookdev.com> (https://github.com/stephencookdev)"
   ],
   "license": "ISC",
   "bugs": {

--- a/src/react-imgix-bg.jsx
+++ b/src/react-imgix-bg.jsx
@@ -26,7 +26,8 @@ const BackgroundImpl = props => {
     className = ""
   } = props;
   const { w: forcedWidth, h: forcedHeight } = imgixParams;
-  const hasDOMDimensions = contentRect.bounds.top != null;
+  const hasDOMDimensions =
+    contentRect.bounds.width != null && contentRect.bounds.height != null;
   const htmlAttributes = props.htmlAttributes || {};
   const dpr = toFixed(2, imgixParams.dpr || global.devicePixelRatio || 1);
   const ref = htmlAttributes.ref;

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -12,6 +12,7 @@ import Imgix, {
   __SourceImpl,
   __PictureImpl
 } from "react-imgix";
+import { __BackgroundImpl } from "react-imgix-bg";
 
 function shallow(element, target = __ReactImgixImpl, shallowOptions) {
   return shallowUntilTarget(element, target, {
@@ -22,6 +23,14 @@ function shallow(element, target = __ReactImgixImpl, shallowOptions) {
 }
 const shallowSource = element => shallow(element, __SourceImpl);
 const shallowPicture = element => shallow(element, __PictureImpl);
+
+const makeBackgroundWithBounds = bounds => props => (
+  <__BackgroundImpl
+    measureRef={() => null}
+    contentRect={{ bounds }}
+    {...props}
+  />
+);
 
 const src = "http://domain.imgix.net/image.jpg";
 let sut;
@@ -501,6 +510,44 @@ describe("When in picture mode", () => {
     expect(onMountedSpy.callCount).toEqual(1);
     const onMountArg = onMountedSpy.lastCall.args[0];
     expect(onMountArg).toBeInstanceOf(HTMLPictureElement);
+  });
+});
+
+describe("When in background mode", () => {
+  it("should be loading when there is a width but no height", () => {
+    const Background = makeBackgroundWithBounds({ top: 10, width: 100 });
+
+    sut = mount(
+      <Background
+        src={`${src}`}
+        className="bg-img"
+        contentRect={{ bounds: { top: 10, width: 100 } }}
+      >
+        <div>Content</div>
+      </Background>
+    );
+
+    expect(sut.find("div.bg-img").hasClass("react-imgix-bg-loading")).toBe(
+      true
+    );
+  });
+
+  it("should not be loading when a width and height are available", () => {
+    const Background = makeBackgroundWithBounds({
+      top: 10,
+      width: 100,
+      height: 100
+    });
+
+    sut = mount(
+      <Background src={`${src}`} className="bg-img">
+        <div>Content</div>
+      </Background>
+    );
+
+    expect(sut.find("div.bg-img").hasClass("react-imgix-bg-loading")).toBe(
+      false
+    );
   });
 });
 


### PR DESCRIPTION
## Description

This PR changes the `hasDOMDimensions` to check for DOM `width` and `height`, rather than just the `top` — which will exist in cases where we still don't want to consider the DOM dimensions "usable".

This should fix #591 — which should, I imagine, stop Imgix from getting quite a few 400s

## Checklist

Please use the checklist that is most closely related to your PR _(you only need to use one checklist, and you can skip items that aren't applicable or don't make sense)_:

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

N/A:
- [x] (done since N/A) Update the readme
- [x] (done since N/A) Update or add any necessary API documentation

## Steps to Test

The new unit test should be sufficient.


But if you want to test manually, too, then create a `<div style={{ width: 100, height: 0 }} /><Background /></div>` element

Related issue: #591
