### PR TITLE
test: htmlAttributes.onLoad and onError for Imgix component

### DIFF
--- a/test/integration/react-imgix.test.jsx
+++ b/test/integration/react-imgix.test.jsx
@@ -147,8 +147,14 @@ const renderAndWaitForImageLoad = async element => {
             element.props.htmlAttributes.onLoad &&
             element.props.htmlAttributes.onLoad();
           setImmediate(() => resolve(renderedEl));
-        }
-      }
+        },
+        onError: () => {
+          element.props.htmlAttributes &&
+            element.props.htmlAttributes.onError &&
+            element.props.htmlAttributes.onError();
+          setImmediate(() => resolve(renderedEl));
+        },
+      },
     });
     renderedEl = renderIntoContainer(elementWithOnMounted);
   });
@@ -188,13 +194,31 @@ describe("When in default mode", () => {
 
       expect(onLoadCalled).toBe(true);
     });
+    it("'onError' calls the callback", async () => {
+      let onErrorCalled = false;
+
+      await renderAndWaitForImageLoad(
+        <Imgix
+          src="https://badurlcom"
+          w={10} // for speed
+          h={10} // for speed
+          htmlAttributes={{
+            onError: () => {
+              onErrorCalled = true;
+            },
+          }}
+        />
+      );
+
+      expect(onErrorCalled).toBe(true);
+    });
   });
 });
 
 describe("Background Mode", () => {
   ///////////////////////
   // Common test cases
-  const shouldRenderNoBGImage = element => {
+  const shouldRenderNoBGImage = (element) => {
     const sut = renderIntoContainer(element);
 
     const container = sut.find(".bg-img").first();

--- a/test/integration/react-imgix.test.jsx
+++ b/test/integration/react-imgix.test.jsx
@@ -143,6 +143,9 @@ const renderAndWaitForImageLoad = async element => {
       htmlAttributes: {
         ...(element.props.htmlAttributes || {}),
         onLoad: () => {
+          element.props.htmlAttributes &&
+            element.props.htmlAttributes.onLoad &&
+            element.props.htmlAttributes.onLoad();
           setImmediate(() => resolve(renderedEl));
         }
       }
@@ -164,6 +167,27 @@ describe("When in default mode", () => {
         .find("img")
         .props().src
     ).toContain(src);
+  });
+
+  context("htmlAttributes", () => {
+    it("'onLoad' calls the callback", async () => {
+      let onLoadCalled = false;
+
+      await renderAndWaitForImageLoad(
+        <Imgix
+          src={src}
+          w={10} // for speed
+          h={10} // for speed
+          htmlAttributes={{
+            onLoad: () => {
+              onLoadCalled = true;
+            },
+          }}
+        />
+      );
+
+      expect(onLoadCalled).toBe(true);
+    });
   });
 });
 


### PR DESCRIPTION
## Description

This PR ensures that onLoad and onError handlers continue to work, since we've advertised this as a feature in the README.

There are no onLoad or onError handlers for Picture or Source elements in the HTML spec. Instead, the onLoad and onError handlers on the fallback image are triggered, no matter which source is chosen. So, this covers those use cases as well.

## Checklist

- [x] All existing unit tests are still passing (if applicable)
- [x] Add new passing unit tests to cover the code introduced by your PR
- [N/A] Update the readme
- [N/A] Update or add any necessary API documentation

## Steps to Test

Review the changes to the tests.



