### PR TITLE
ci(browserstack): reduce false-negative build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ branches:
 
 node_js:
   - "9"
+
+script:
+  - travis_retry npm test

--- a/config/karma/karmaConfig.js
+++ b/config/karma/karmaConfig.js
@@ -15,9 +15,9 @@ const baseConfig = {
     "../../test/tests.webpack.js": "webpack"
   },
   reporters: ["mocha"],
-  captureTimeout: 90000,
+  captureTimeout: 100000,
   browserConnectTimeout: 3000,
-  browserNoActivityTimeout: 15000,
+  browserNoActivityTimeout: 60000,
   webpack: webpackConfig,
   webpackMiddleware: {},
   concurrency: 5


### PR DESCRIPTION
This PR presents an attempt to mitigate the number of breaking TravisCI builds, specifically caused by Karma/BrowserStack timeouts. There are two main ways that a timeout can occur:

- **Within a single build**: One or more slow karma tests can delay the execution of subsequent tests, as there is a limit to the number of workers that can be run in parallel. If this delay occurs for long enough, the subsequent tests will not have enough time to complete prior to hitting the `captureTimeout` limit. We cannot configure the workers directly, but we can permit a higher timeout limit to give other tests ample time complete.
- **Across multiple builds**: All builds are run under the same BrowserStack account, which are subject to a non-configurable API rate limit of 800 requests per 5 minutes. If multiple builds are run at once, e.g. @renovate-bot merges the base branch back into multiple Pull Requests, this API limit can be hit. We can mitigate this by limiting the [number of concurrent jobs](https://docs.travis-ci.com/user/customizing-the-build/#limiting-concurrent-jobs) that Travis runs at once.

So far, I have rerun CI on this branch ~10 times without timeout. While this may result in longer average execution times per build, I am confident it will save our team time in the long run by not having to manually restart timed-out builds.