### PR TITLE
chore: replace ref to master with main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
 
 branches:
   only:
-    - master
+    - main
     - /release.*/
 
 node_js:


### PR DESCRIPTION
Follow up to #673, replaces a missed reference to `master`