### PR TITLE
chore: fix license link to coursera

### DIFF
--- a/src/constructUrl.js
+++ b/src/constructUrl.js
@@ -1,6 +1,6 @@
 /*
 Copyright © 2015 by Coursera
-Licensed under the Apache License 2.0, seen https://github.com/coursera/react-imgix/blob/main/LICENSE
+Licensed under the Apache License 2.0, seen https://github.com/coursera/react-imgix/blob/master/LICENSE
 
 Minor syntax modifications have been made
 */


### PR DESCRIPTION
This follows up on a typo from #673.