### PR TITLE
ci: update supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ branches:
     - /release.*/
 
 node_js:
-  - "9"
+  - lts/*
+  - stable
 
 script:
   - travis_retry npm test

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   },
   "peerDependencies": {
     "prop-types": ">=15.5.6",
-    "react": ">=15",
-    "react-dom": ">=15"
+    "react": "15.x || 16.x || 17.x",
+    "react-dom": "15.x || 16.x || 17.x"
   },
   "dependencies": {
     "js-base64": "~2.6.0",


### PR DESCRIPTION
Adds [currently supported](https://nodejs.org/en/about/releases/) LTS node versions to CI.

TODO: remove EOL'd versions in a future major release