### PR TITLE
test(react-imgix-test): change src url to valid url

### DIFF
--- a/test/integration/react-imgix.test.jsx
+++ b/test/integration/react-imgix.test.jsx
@@ -195,9 +195,7 @@ describe("When in default mode", () => {
 
       await renderAndWaitForImageLoad(
         <Imgix
-          src="https://badurlcom"
-          w={10} // for speed
-          h={10} // for speed
+          src="http://captive.apple.com"
           htmlAttributes={{
             onError: () => {
               onErrorCalled = true;


### PR DESCRIPTION
## Description

- this pr fixes a bug where an `onError` callback didn't fire in one of the test suites. This is related to [an old firefox bug discussion](https://bugzilla.mozilla.org/show_bug.cgi?id=299138), where they establish that, per [HTML5 spec]( http://www.whatwg.org/specs/web-apps/current-work/#the-img-element):

> "Whether the image is fetched successfully or not (e.g. whether the response code was a 2xx code or equivalent) must be ignored when determining the image's type and whether it is a valid image."

## Checklist

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Code:

```console
npm run test:browser
```
