### PR TITLE
config(semantic): fix package version replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,8 +232,8 @@
               "files": [
                 "src/constants.js"
               ],
-              "from": "const PACKAGE_VERSION = '.*'",
-              "to": "const PACKAGE_VERSION = '${nextRelease.version}'",
+              "from": "const PACKAGE_VERSION = \".*\"",
+              "to": "const PACKAGE_VERSION = \"${nextRelease.version}\"",
               "results": [
                 {
                   "file": "src/constants.js",


### PR DESCRIPTION
Looks like we are using double quotes rather than single quotes in this lib, which caused the semantic release step to fail.

I can't easily guarantee this works, will have to merge to main to see if it does.