### PR TITLE
feat: create imgixProvider component

### DIFF
--- a/src/HOCs/imgixProvider.jsx
+++ b/src/HOCs/imgixProvider.jsx
@@ -3,10 +3,9 @@ import React, { useContext, createContext } from 'react'
 const ImgixContext = createContext()
 
 /**
- * `useImgixContext()` tries to invoke `React.useContext()`. If context is 
- * `undefined`, we know that the context is being accessed outside of a 
- * provider, and therefore throw an `Error`.
- * @returns Hook that gets context value from the nearest`ImgixProvider`.
+ * `useImgixContext()` tries to invoke `React.useContext()`. If no context
+ * is available, this function returns `undefined`. 
+ * @returns The context defined by the closest parent `ImgixProvider`.
  */
 function useImgixContext() {
   return useContext(ImgixContext)
@@ -37,4 +36,3 @@ function ImgixProvider({children, ...reactImgixProps}) {
 // }
 
 export {ImgixProvider, useImgixContext}
-

--- a/src/HOCs/imgixProvider.jsx
+++ b/src/HOCs/imgixProvider.jsx
@@ -9,11 +9,7 @@ const ImgixContext = createContext()
  * @returns Hook that gets context value from the nearest`ImgixProvider`.
  */
 function useImgixContext() {
-  const context = useContext(ImgixContext)
-  if (context === undefined) {
-    console.error("useImgixContext must be used within a ImgixProvider")
-  }
-  return context
+  return useContext(ImgixContext)
 }
 
 /**
@@ -27,6 +23,9 @@ function useImgixContext() {
 function ImgixProvider({children, ...reactImgixProps}) {
   const value = reactImgixProps
 
+  if ( children == null || children.length < 1) {
+    console.error("ImgixProvider must have at least one Imgix child component")
+  }
   return <ImgixContext.Provider value={value}>{children}</ImgixContext.Provider>
 }
 

--- a/src/HOCs/imgixProvider.jsx
+++ b/src/HOCs/imgixProvider.jsx
@@ -28,11 +28,4 @@ function ImgixProvider({children, ...reactImgixProps}) {
   return <ImgixContext.Provider value={value}>{children}</ImgixContext.Provider>
 }
 
-
-//TODO(luis): do we still need this?
-// const propsProcessorHOF = (Component) => (props) => {
-//   const collapsedImgixParams = collapseImgixParam(props.imgixParams);
-//   return <Component {...props} imgixParams={collapsedImgixParams} />
-// }
-
 export {ImgixProvider, useImgixContext}

--- a/src/HOCs/imgixProvider.jsx
+++ b/src/HOCs/imgixProvider.jsx
@@ -17,7 +17,7 @@ function useImgixContext() {
  * `React.useContext()` API.
  * @param {React.Element <typeof Component>} children 
  * @param {Object} reactImgixProps 
- * @returns Component
+ * @returns React.Element
  */
 function ImgixProvider({children, ...reactImgixProps}) {
   const value = reactImgixProps

--- a/src/HOCs/imgixProvider.jsx
+++ b/src/HOCs/imgixProvider.jsx
@@ -1,0 +1,41 @@
+import React, { useContext, createContext } from 'react'
+
+const ImgixContext = createContext()
+
+/**
+ * `useImgixContext()` tries to invoke `React.useContext()`. If context is 
+ * `undefined`, we know that the context is being accessed outside of a 
+ * provider, and therefore throw an `Error`.
+ * @returns Hook that gets context value from the nearest`ImgixProvider`.
+ */
+function useImgixContext() {
+  const context = useContext(ImgixContext)
+  if (context === undefined) {
+    console.error("useImgixContext must be used within a ImgixProvider")
+  }
+  return context
+}
+
+/**
+ * Creates a Provider component that passes `reactImgixProps` as the Context 
+ * for child components who use the `useImgixContext()` custom hook or 
+ * `React.useContext()` API.
+ * @param {React.Element <typeof Component>} children 
+ * @param {Object} reactImgixProps 
+ * @returns Component
+ */
+function ImgixProvider({children, ...reactImgixProps}) {
+  const value = reactImgixProps
+
+  return <ImgixContext.Provider value={value}>{children}</ImgixContext.Provider>
+}
+
+
+//TODO(luis): do we still need this?
+// const propsProcessorHOF = (Component) => (props) => {
+//   const collapsedImgixParams = collapseImgixParam(props.imgixParams);
+//   return <Component {...props} imgixParams={collapsedImgixParams} />
+// }
+
+export {ImgixProvider, useImgixContext}
+

--- a/test/unit/imgix-provider.test.jsx
+++ b/test/unit/imgix-provider.test.jsx
@@ -1,0 +1,107 @@
+import { mount, shallow } from 'enzyme';
+import React from 'react';
+import ReactImgix, { ImgixProvider } from "../../src/index"
+
+const providerProps = {
+  domain: "sdk-test.imgix.net",
+  sizes: "100vw",
+}
+
+const imageProps = {
+  src: "https://assets.imgix.net/examples/pione.jpg",
+  sizes: "50vw",
+}
+
+describe('ImgixProvider', () => {
+
+  test('should not have context value defined if Provider has no props', () => {
+    const wrappedComponent = (
+      <ImgixProvider>
+        <ReactImgix {...imageProps}/>
+      </ImgixProvider>
+    )
+
+    const expectedProps = {
+      children: < ReactImgix src="https://assets.imgix.net/examples/pione.jpg" sizes="50vw" />,
+      value: {}
+    }
+
+    const renderedComponent = shallow(wrappedComponent)
+    expect(renderedComponent.props()).toEqual(expectedProps)
+  })
+
+  test('should set the context value to the Provider props', () => {
+    const wrappedComponent = (
+      <ImgixProvider {...providerProps}>
+        <ReactImgix {...imageProps}/>
+      </ImgixProvider>
+    )
+
+    // ensure Provider value correct set
+    const expectedProps = {
+      children: < ReactImgix src="https://assets.imgix.net/examples/pione.jpg" sizes="50vw" />,
+      value: { domain: "sdk-test.imgix.net", sizes: "100vw", }
+    }
+
+    const renderedComponent = shallow(wrappedComponent)
+    expect(renderedComponent.props()).toEqual(expectedProps)
+  })
+
+  test('should merge the Provider and Child props', () => {
+
+    const modifiedProps = { ...imageProps };
+    modifiedProps.src = "examples/pione.jpg"
+    modifiedProps.sizes = null
+
+    const wrappedComponent = (
+      <ImgixProvider {...providerProps}>
+        <ReactImgix {...modifiedProps}/>
+      </ImgixProvider>
+    )
+
+    // ensure Provider and Child props are merged as intended
+    const expectedProps = {
+      disableSrcSet: false,
+      domain: "sdk-test.imgix.net",
+      height: null,
+      imgixParams: undefined,
+      onMounted: undefined,
+      sizes: "100vw",
+      src: "https://sdk-test.imgix.net/examples/pione.jpg",
+      width: null,
+    }
+
+    const renderedComponent = mount(wrappedComponent)
+    const renderedProps = renderedComponent
+      .childAt(0) // mergePropsHOF
+      .childAt(0) // processPropsHOF
+      .childAt(0) // ChildComponent
+      .props()
+    // remove noop function that breaks tests
+    renderedProps.onMounted = undefined
+
+    expect(renderedProps).toEqual(expectedProps)
+  })
+
+  test('should log error when has no consumers', () => {
+    jest.spyOn(global.console, 'error').mockImplementation(() => {})
+
+    const wrappedComponent = (
+      <ImgixProvider {...providerProps}>
+      </ImgixProvider>
+    )
+
+    const expectedProps = {
+      children: undefined,
+      value: providerProps
+    }
+
+    const renderedComponent = shallow(wrappedComponent)
+
+    expect(renderedComponent.props()).toEqual(expectedProps)
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("ImgixProvider must have at least one Imgix child component")
+    );
+  })
+})
+

--- a/test/unit/imgix-provider.test.jsx
+++ b/test/unit/imgix-provider.test.jsx
@@ -1,52 +1,61 @@
-import { mount, shallow } from 'enzyme';
-import React from 'react';
-import ReactImgix from "../../src/index"
-import { ImgixProvider } from "../../es/HOCs/imgixProvider"
+import { mount, shallow } from "enzyme";
+import React from "react";
+import ReactImgix from "../../src/index";
+import { ImgixProvider } from "../../es/HOCs/imgixProvider";
 
 const providerProps = {
   domain: "sdk-test.imgix.net",
   sizes: "100vw",
-}
+};
 
 const imageProps = {
   src: "https://assets.imgix.net/examples/pione.jpg",
   sizes: "50vw",
-}
+};
 
-describe('ImgixProvider', () => {
-
-  test('should not have context value defined if Provider has no props', () => {
+describe("ImgixProvider", () => {
+  test("should not have context value defined if Provider has no props", () => {
     const wrappedComponent = (
       <ImgixProvider>
-        <ReactImgix {...imageProps}/>
+        <ReactImgix {...imageProps} />
       </ImgixProvider>
-    )
+    );
 
     const expectedProps = {
-      children: < ReactImgix src="https://assets.imgix.net/examples/pione.jpg" sizes="50vw" />,
-      value: {}
-    }
+      children: (
+        <ReactImgix
+          src="https://assets.imgix.net/examples/pione.jpg"
+          sizes="50vw"
+        />
+      ),
+      value: {},
+    };
 
-    const renderedComponent = shallow(wrappedComponent)
-    expect(renderedComponent.props()).toEqual(expectedProps)
-  })
+    const renderedComponent = shallow(wrappedComponent);
+    expect(renderedComponent.props()).toEqual(expectedProps);
+  });
 
-  test('should set the context value to the Provider props', () => {
+  test("should set the context value to the Provider props", () => {
     const wrappedComponent = (
       <ImgixProvider {...providerProps}>
-        <ReactImgix {...imageProps}/>
+        <ReactImgix {...imageProps} />
       </ImgixProvider>
-    )
+    );
 
     // ensure Provider value correctly set
     const expectedProps = {
-      children: < ReactImgix src="https://assets.imgix.net/examples/pione.jpg" sizes="50vw" />,
-      value: { domain: "sdk-test.imgix.net", sizes: "100vw", }
-    }
+      children: (
+        <ReactImgix
+          src="https://assets.imgix.net/examples/pione.jpg"
+          sizes="50vw"
+        />
+      ),
+      value: { domain: "sdk-test.imgix.net", sizes: "100vw" },
+    };
 
-    const renderedComponent = shallow(wrappedComponent)
-    expect(renderedComponent.props()).toEqual(expectedProps)
-  })
+    const renderedComponent = shallow(wrappedComponent);
+    expect(renderedComponent.props()).toEqual(expectedProps);
+  });
 
   // TODO(luis): enable these tests once propMerger and propProcessor merged in
   // test('should merge the Provider and Child props', () => {
@@ -105,5 +114,4 @@ describe('ImgixProvider', () => {
   //     expect.stringContaining("ImgixProvider must have at least one Imgix child component")
   //   );
   // })
-})
-
+});

--- a/test/unit/imgix-provider.test.jsx
+++ b/test/unit/imgix-provider.test.jsx
@@ -1,6 +1,7 @@
 import { mount, shallow } from 'enzyme';
 import React from 'react';
-import ReactImgix, { ImgixProvider } from "../../src/index"
+import ReactImgix from "../../src/index"
+import { ImgixProvider } from "../../es/HOCs/index"
 
 const providerProps = {
   domain: "sdk-test.imgix.net",
@@ -47,61 +48,62 @@ describe('ImgixProvider', () => {
     expect(renderedComponent.props()).toEqual(expectedProps)
   })
 
-  test('should merge the Provider and Child props', () => {
+  // TODO(luis): enable these tests once propMerger and propProcessor merged in
+  // test('should merge the Provider and Child props', () => {
 
-    const modifiedProps = { ...imageProps };
-    modifiedProps.src = "examples/pione.jpg"
-    modifiedProps.sizes = null
+  //   const modifiedProps = { ...imageProps };
+  //   modifiedProps.src = "examples/pione.jpg"
+  //   modifiedProps.sizes = null
 
-    const wrappedComponent = (
-      <ImgixProvider {...providerProps}>
-        <ReactImgix {...modifiedProps}/>
-      </ImgixProvider>
-    )
+  //   const wrappedComponent = (
+  //     <ImgixProvider {...providerProps}>
+  //       <ReactImgix {...modifiedProps}/>
+  //     </ImgixProvider>
+  //   )
 
-    // ensure Provider and Child props are merged as intended
-    const expectedProps = {
-      disableSrcSet: false,
-      domain: "sdk-test.imgix.net",
-      height: null,
-      imgixParams: undefined,
-      onMounted: undefined,
-      sizes: "100vw",
-      src: "https://sdk-test.imgix.net/examples/pione.jpg",
-      width: null,
-    }
+  //   // ensure Provider and Child props are merged as intended
+  //   const expectedProps = {
+  //     disableSrcSet: false,
+  //     domain: "sdk-test.imgix.net",
+  //     height: null,
+  //     imgixParams: undefined,
+  //     onMounted: undefined,
+  //     sizes: "100vw",
+  //     src: "https://sdk-test.imgix.net/examples/pione.jpg",
+  //     width: null,
+  //   }
 
-    const renderedComponent = mount(wrappedComponent)
-    const renderedProps = renderedComponent
-      .childAt(0) // mergePropsHOF
-      .childAt(0) // processPropsHOF
-      .childAt(0) // ChildComponent
-      .props()
-    // remove noop function that breaks tests
-    renderedProps.onMounted = undefined
+  //   const renderedComponent = mount(wrappedComponent)
+  //   const renderedProps = renderedComponent
+  //     .childAt(0) // mergePropsHOF
+  //     .childAt(0) // processPropsHOF
+  //     .childAt(0) // ChildComponent
+  //     .props()
+  //   // remove noop function that breaks tests
+  //   renderedProps.onMounted = undefined
 
-    expect(renderedProps).toEqual(expectedProps)
-  })
+  //   expect(renderedProps).toEqual(expectedProps)
+  // })
 
-  test('should log error when has no consumers', () => {
-    jest.spyOn(global.console, 'error').mockImplementation(() => {})
+  // test('should log error when has no consumers', () => {
+  //   jest.spyOn(global.console, 'error').mockImplementation(() => {})
 
-    const wrappedComponent = (
-      <ImgixProvider {...providerProps}>
-      </ImgixProvider>
-    )
+  //   const wrappedComponent = (
+  //     <ImgixProvider {...providerProps}>
+  //     </ImgixProvider>
+  //   )
 
-    const expectedProps = {
-      children: undefined,
-      value: providerProps
-    }
+  //   const expectedProps = {
+  //     children: undefined,
+  //     value: providerProps
+  //   }
 
-    const renderedComponent = shallow(wrappedComponent)
+  //   const renderedComponent = shallow(wrappedComponent)
 
-    expect(renderedComponent.props()).toEqual(expectedProps)
-    expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining("ImgixProvider must have at least one Imgix child component")
-    );
-  })
+  //   expect(renderedComponent.props()).toEqual(expectedProps)
+  //   expect(console.error).toHaveBeenCalledWith(
+  //     expect.stringContaining("ImgixProvider must have at least one Imgix child component")
+  //   );
+  // })
 })
 

--- a/test/unit/imgix-provider.test.jsx
+++ b/test/unit/imgix-provider.test.jsx
@@ -1,7 +1,7 @@
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 import ReactImgix from "../../src/index"
-import { ImgixProvider } from "../../es/HOCs/index"
+import { ImgixProvider } from "../../es/HOCs/imgixProvider"
 
 const providerProps = {
   domain: "sdk-test.imgix.net",

--- a/test/unit/imgix-provider.test.jsx
+++ b/test/unit/imgix-provider.test.jsx
@@ -37,7 +37,7 @@ describe('ImgixProvider', () => {
       </ImgixProvider>
     )
 
-    // ensure Provider value correct set
+    // ensure Provider value correctly set
     const expectedProps = {
       children: < ReactImgix src="https://assets.imgix.net/examples/pione.jpg" sizes="50vw" />,
       value: { domain: "sdk-test.imgix.net", sizes: "100vw", }

--- a/test/unit/imgix-provider.test.jsx
+++ b/test/unit/imgix-provider.test.jsx
@@ -57,61 +57,20 @@ describe("ImgixProvider", () => {
     expect(renderedComponent.props()).toEqual(expectedProps);
   });
 
-  // TODO(luis): enable these tests once propMerger and propProcessor merged in
-  // test('should merge the Provider and Child props', () => {
+  test('should log error when has no consumers', () => {
+    jest.spyOn(global.console, 'error').mockImplementation(() => {})
 
-  //   const modifiedProps = { ...imageProps };
-  //   modifiedProps.src = "examples/pione.jpg"
-  //   modifiedProps.sizes = null
+    const wrappedComponent = (
+      <ImgixProvider {...providerProps}>
+      </ImgixProvider>
+    )
 
-  //   const wrappedComponent = (
-  //     <ImgixProvider {...providerProps}>
-  //       <ReactImgix {...modifiedProps}/>
-  //     </ImgixProvider>
-  //   )
+    shallow(wrappedComponent)
 
-  //   // ensure Provider and Child props are merged as intended
-  //   const expectedProps = {
-  //     disableSrcSet: false,
-  //     domain: "sdk-test.imgix.net",
-  //     height: null,
-  //     imgixParams: undefined,
-  //     onMounted: undefined,
-  //     sizes: "100vw",
-  //     src: "https://sdk-test.imgix.net/examples/pione.jpg",
-  //     width: null,
-  //   }
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("ImgixProvider must have at least one Imgix child component")
+    );
 
-  //   const renderedComponent = mount(wrappedComponent)
-  //   const renderedProps = renderedComponent
-  //     .childAt(0) // mergePropsHOF
-  //     .childAt(0) // processPropsHOF
-  //     .childAt(0) // ChildComponent
-  //     .props()
-  //   // remove noop function that breaks tests
-  //   renderedProps.onMounted = undefined
-
-  //   expect(renderedProps).toEqual(expectedProps)
-  // })
-
-  // test('should log error when has no consumers', () => {
-  //   jest.spyOn(global.console, 'error').mockImplementation(() => {})
-
-  //   const wrappedComponent = (
-  //     <ImgixProvider {...providerProps}>
-  //     </ImgixProvider>
-  //   )
-
-  //   const expectedProps = {
-  //     children: undefined,
-  //     value: providerProps
-  //   }
-
-  //   const renderedComponent = shallow(wrappedComponent)
-
-  //   expect(renderedComponent.props()).toEqual(expectedProps)
-  //   expect(console.error).toHaveBeenCalledWith(
-  //     expect.stringContaining("ImgixProvider must have at least one Imgix child component")
-  //   );
-  // })
+    jest.clearAllMocks();
+  })
 });


### PR DESCRIPTION
This PR is part of a stack

| PR 	| Title 	| Merges Into 	|   	|
|----	|-------	|-------------	|---	|
|    1	|    [imgixProvider](https://github.com/imgix/react-imgix/pull/791) 👈🏼  	|        [luis/PE-828](https://github.com/imgix/react-imgix/tree/luis/PE-828)    	|   	|
|    2	|    [propsMerger](https://github.com/imgix/react-imgix/pull/790)     	|           #791  	|   	|
|    3	|    [wrapReactImgix](https://github.com/imgix/react-imgix/pull/792)    	|       #790      	|   	|
----
This commit creates a Provider component, `<ImgixProvider />`. The
component uses the `React.createContext()` API to create a props context
that can be modified and passed on to its child components. This is
useful as it allows for HOF that can format and combine imgixProps
before they're passed on `<ReactImgix />`. In order to, for example,
support 2-part URLs, IE domain + path, we can use the Provider to pass
these props to a HOF props merger, format the 2 parts into one combined
URL and finally pass the combined props to `<ReactImgix />`.

This allows us to leave the current API for `<ReactImgix>` unchanged while
also unchanged while also adding support for new props now and in the
future.

For example, the ImgixProvider can store a domain prop that is shared
across multiple `<ReactImgix>` components, each with a distinct src prop.
Inside the Provider, the props reducer combined the shared domain prop
with the src props to create a one-step URL.