### PR TITLE
feat: wrap ReactImgix in mergePropsHOF

### DIFF
--- a/src/HOCs/index.js
+++ b/src/HOCs/index.js
@@ -1,1 +1,2 @@
 export * from "./shouldComponentUpdateHOC";
+export * from "./imgixProvider"

--- a/src/constructUrl.js
+++ b/src/constructUrl.js
@@ -21,6 +21,7 @@ var PARAM_EXPANSION = Object.freeze({
   invert: "invert",
   saturation: "sat",
   shaddows: "shad",
+  shadows: "shad",
   sharpness: "sharp",
   "unsharp-mask": "usm",
   "unsharp-radius": "usmrad",

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
 import ReactImgix, { Picture, Source } from "./react-imgix";
 import { PublicConfigAPI } from "./config";
-
 import { buildURLPublic as buildURL } from "./constructUrl";
+import {
+  ImgixProvider,
+} from "./HOCs"
+
+export { ImgixProvider };
 export { buildURL };
-
-export default ReactImgix;
 export { Picture, Source, PublicConfigAPI };
-
 export { Background } from "./react-imgix-bg";
+export default ReactImgix;

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -9,6 +9,7 @@ import constructUrl, {
 } from "./constructUrl";
 import extractQueryParams from "./extractQueryParams";
 import { ShouldComponentUpdateHOC } from "./HOCs";
+import { mergeComponentPropsHOF, processPropsHOF } from "./HOFs";
 
 const NODE_ENV = process.env.NODE_ENV;
 
@@ -367,9 +368,13 @@ class SourceImpl extends Component {
 }
 SourceImpl.displayName = "ReactImgixSource";
 
-const ReactImgixWrapped = compose(ShouldComponentUpdateHOC)(ReactImgix);
-const Picture = compose(ShouldComponentUpdateHOC)(PictureImpl);
-const Source = compose(ShouldComponentUpdateHOC)(SourceImpl);
+let ReactImgixWrapped = compose()(ShouldComponentUpdateHOC)(ReactImgix);
+let Picture = compose()(ShouldComponentUpdateHOC)(PictureImpl);
+let Source = compose()(ShouldComponentUpdateHOC)(SourceImpl);
+
+ReactImgixWrapped = mergeComponentPropsHOF(processPropsHOF(ReactImgix))
+Picture = mergeComponentPropsHOF(processPropsHOF(PictureImpl))
+Source = mergeComponentPropsHOF(processPropsHOF(SourceImpl))
 
 export default ReactImgixWrapped;
 export {

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import "./array-findindex";
-import { compose, config } from "./common";
+import { config } from "./common";
 import { PACKAGE_VERSION } from "./constants";
 import constructUrl, {
   compactParamKeys,
@@ -368,13 +368,15 @@ class SourceImpl extends Component {
 }
 SourceImpl.displayName = "ReactImgixSource";
 
-let ReactImgixWrapped = compose()(ShouldComponentUpdateHOC)(ReactImgix);
-let Picture = compose()(ShouldComponentUpdateHOC)(PictureImpl);
-let Source = compose()(ShouldComponentUpdateHOC)(SourceImpl);
-
-ReactImgixWrapped = mergeComponentPropsHOF(processPropsHOF(ReactImgix))
-Picture = mergeComponentPropsHOF(processPropsHOF(PictureImpl))
-Source = mergeComponentPropsHOF(processPropsHOF(SourceImpl))
+const ReactImgixWrapped = (
+  mergeComponentPropsHOF(processPropsHOF(ShouldComponentUpdateHOC(ReactImgix)))
+);
+const Picture = (
+  mergeComponentPropsHOF(processPropsHOF(ShouldComponentUpdateHOC(PictureImpl)))
+);
+const Source = (
+  mergeComponentPropsHOF(processPropsHOF(ShouldComponentUpdateHOC(SourceImpl)))
+);
 
 export default ReactImgixWrapped;
 export {

--- a/test/unit/imgix-provider.test.jsx
+++ b/test/unit/imgix-provider.test.jsx
@@ -53,9 +53,11 @@ describe("ImgixProvider", () => {
 
   test('should merge the Provider and Child props', () => {
 
-    const modifiedProps = { ...imageProps };
-    modifiedProps.src = "examples/pione.jpg"
-    modifiedProps.sizes = null
+    const modifiedProps = {
+      ...imageProps,
+      src: "examples/pione.jpg",
+      sizes: null
+    };
 
     const wrappedComponent = (
       <ImgixProvider {...providerProps}>
@@ -65,21 +67,24 @@ describe("ImgixProvider", () => {
 
     // ensure Provider and Child props are merged as intended
     const expectedProps = {
+      disableSrcSet: false,
       domain: "sdk-test.imgix.net",
-      height: null,
+      height: undefined,
       imgixParams: undefined,
       onMounted: undefined,
-      sizes: "100vw",
+      sizes: null,
       src: "https://sdk-test.imgix.net/examples/pione.jpg",
-      width: null,
+      width: undefined,
     }
 
+    // The order of the childAt() needs to update if number of HOCs change.
     const renderedComponent = mount(wrappedComponent)
     const renderedProps = renderedComponent
-      .childAt(0) // mergePropsHOF
-      .childAt(0) // processPropsHOF
-      .childAt(0) // ChildComponent
-      .props()
+    .childAt(0) // mergePropsHOF
+    .childAt(0) // processPropsHOF
+    .childAt(0) // shouldComponentUpdateHOC
+    .childAt(0) // ChildComponent
+    .props()
     // remove noop function that breaks tests
     renderedProps.onMounted = undefined
 

--- a/test/unit/imgix-provider.test.jsx
+++ b/test/unit/imgix-provider.test.jsx
@@ -44,29 +44,66 @@ describe("ImgixProvider", () => {
 
     // ensure Provider value correctly set
     const expectedProps = {
-      children: (
-        <ReactImgix
-          src="https://assets.imgix.net/examples/pione.jpg"
-          sizes="50vw"
-        />
-      ),
-      value: { domain: "sdk-test.imgix.net", sizes: "100vw" },
-    };
+      children: < ReactImgix src="https://assets.imgix.net/examples/pione.jpg" sizes="50vw" />,
+      value: { domain: "sdk-test.imgix.net", sizes: "100vw", }
+    }
 
-    const renderedComponent = shallow(wrappedComponent);
-    expect(renderedComponent.props()).toEqual(expectedProps);
-  });
+    const renderedComponent = shallow(wrappedComponent)
+    expect(renderedComponent.props()).toEqual(expectedProps)
+  })
+
+  test('should merge the Provider and Child props', () => {
+
+    const modifiedProps = { ...imageProps };
+    modifiedProps.src = "examples/pione.jpg"
+    modifiedProps.sizes = null
+
+    const wrappedComponent = (
+      <ImgixProvider {...providerProps}>
+        <ReactImgix {...modifiedProps} />
+      </ImgixProvider>
+    )
+
+    // ensure Provider and Child props are merged as intended
+    const expectedProps = {
+      disableSrcSet: false,
+      domain: "sdk-test.imgix.net",
+      height: null,
+      imgixParams: undefined,
+      onMounted: undefined,
+      sizes: "100vw",
+      src: "https://sdk-test.imgix.net/examples/pione.jpg",
+      width: null,
+    }
+
+    const renderedComponent = mount(wrappedComponent)
+    const renderedProps = renderedComponent
+      .childAt(0) // mergePropsHOF
+      .childAt(0) // processPropsHOF
+      .childAt(0) // ChildComponent
+      .props()
+    // remove noop function that breaks tests
+    renderedProps.onMounted = undefined
+
+    expect(renderedProps).toEqual(expectedProps)
+  })
 
   test('should log error when has no consumers', () => {
-    jest.spyOn(global.console, 'error').mockImplementation(() => {})
+    jest.spyOn(global.console, 'error').mockImplementation(() => { })
 
     const wrappedComponent = (
       <ImgixProvider {...providerProps}>
       </ImgixProvider>
     )
 
-    shallow(wrappedComponent)
+    const expectedProps = {
+      children: undefined,
+      value: providerProps
+    }
 
+    const renderedComponent = shallow(wrappedComponent)
+
+    expect(renderedComponent.props()).toEqual(expectedProps)
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("ImgixProvider must have at least one Imgix child component")
     );

--- a/test/unit/imgix-provider.test.jsx
+++ b/test/unit/imgix-provider.test.jsx
@@ -65,7 +65,6 @@ describe("ImgixProvider", () => {
 
     // ensure Provider and Child props are merged as intended
     const expectedProps = {
-      disableSrcSet: false,
       domain: "sdk-test.imgix.net",
       height: null,
       imgixParams: undefined,

--- a/test/unit/imgix-provider.test.jsx
+++ b/test/unit/imgix-provider.test.jsx
@@ -1,7 +1,6 @@
-import { mount, shallow } from "enzyme";
-import React from "react";
-import ReactImgix from "../../src/index";
-import { ImgixProvider } from "../../es/HOCs/imgixProvider";
+import { mount, shallow } from 'enzyme';
+import React from 'react';
+import ReactImgix, { ImgixProvider } from "../../src/index"
 
 const providerProps = {
   domain: "sdk-test.imgix.net",

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -400,7 +400,13 @@ describe("When in picture mode", () => {
 
     it("an <img> or a <Imgix> should be the last child", () => {
       // If the number of HOCs for ReactImgix is changed, there may need to be a change in the number of .first().shallow() calls
-      const lastChildElement = lastChild.first().shallow().first().shallow(); // hack from https://github.com/airbnb/enzyme/issues/539#issuecomment-239497107 until a better solution is implemented
+      // hack from https://github.com/airbnb/enzyme/issues/539#issuecomment-239497107 until a better solution is implemented
+      const lastChildElement = lastChild.first()
+        .shallow()
+        .first()
+        .shallow()
+        .first()
+        .shallow();
       if (lastChildElement.type().hasOwnProperty("name")) {
         expect(lastChildElement.name()).toBe(__ReactImgixImpl.displayName);
         expect(

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -41,10 +41,13 @@ const makeBackgroundWithBounds = (bounds) => (props) => (
 
 const src = "http://domain.imgix.net/image.jpg";
 let sut;
-jest.spyOn(global.console, 'error').mockImplementation((error) => {console.log(error)})
+// TODO(luis): do we need to mock error? There's a react error logging that
+// might make the test-suite fail on CI.
+// jest.spyOn(global.console, 'error').mockImplementation((error) => { console.log(error) })
+jest.spyOn(global.console, 'warn').mockImplementation((msg) => {console.log(msg)})
 
 describe("When in default mode", () => {
-  it.only("the rendered element's type should be img", () => {
+  it("the rendered element's type should be img", () => {
     const sut = shallow(<Imgix src={src} sizes="100vw" />);
     expect(sut.type()).toBe("img");
   });

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -41,9 +41,6 @@ const makeBackgroundWithBounds = (bounds) => (props) => (
 
 const src = "http://domain.imgix.net/image.jpg";
 let sut;
-// TODO(luis): do we need to mock error? There's a react error logging that
-// might make the test-suite fail on CI.
-// jest.spyOn(global.console, 'error').mockImplementation((error) => { console.log(error) })
 jest.spyOn(global.console, 'warn').mockImplementation((msg) => {console.log(msg)})
 
 describe("When in default mode", () => {

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -41,26 +41,10 @@ const makeBackgroundWithBounds = (bounds) => (props) => (
 
 const src = "http://domain.imgix.net/image.jpg";
 let sut;
-let oldConsole, log;
-
-beforeEach(() => {
-  oldConsole = global.console;
-  delete console.log;
-  console.error = console.log;
-  log = console.log.bind(console);
-});
-afterEach(() => {
-  global.console = oldConsole;
-});
-
-function sleep(ms) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
+jest.spyOn(global.console, 'error').mockImplementation((error) => {console.log(error)})
 
 describe("When in default mode", () => {
-  it("the rendered element's type should be img", () => {
+  it.only("the rendered element's type should be img", () => {
     const sut = shallow(<Imgix src={src} sizes="100vw" />);
     expect(sut.type()).toBe("img");
   });
@@ -426,16 +410,11 @@ describe("When in picture mode", () => {
   };
 
   it("should throw an error when no children passed", () => {
-    const oldConsole = global.console;
-    global.console = { warn: jest.fn() };
-
     shallowPicture(<Picture src={src} width={100} height={100} />);
 
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining("No fallback <img /> or <Imgix /> found")
     );
-
-    global.console = oldConsole;
   });
 
   describe("with a <Imgix> passed as a child", () => {
@@ -741,8 +720,6 @@ describe("When using the component", () => {
     describe("invalid AR", () => {
       const testInvalidAR = (ar) => {
         it(`an invalid ar prop (${ar}) will still generate an ar query parameter`, () => {
-          const oldConsole = global.console;
-          global.console = { warn: jest.fn() };
 
           const parseParam = (url, param) => {
             const matched = url.match("[?&]" + param + "=([^&]+)");
@@ -769,8 +746,6 @@ describe("When using the component", () => {
             expect(w).toBeTruthy();
             expect(ar).toBeTruthy();
           });
-
-          global.console = oldConsole;
         });
       };
 


### PR DESCRIPTION
This PR uses the `mergePropsHOF` to wrap `ReactImgix` components with the ImgixContext. 

It also fixes a spelling mistake in the prop expander (b2fa08d).

- `mergePropsHOF` checks if ReactImgix is within an `ImgixContext`. 
- If it is, it combined the Provider and Child props and renders `ReactImgix` with the combined props. 
- If it isn't it renders `ReactImgix` with the props as-is.


https://user-images.githubusercontent.com/16711614/119424185-f97ffa00-bcd2-11eb-8722-729938995e84.mov

### todo
The prop expander (b2fa08d) fix should probably be removed form this PR and made into a standalone PR.

---
This PR is part of a stack

| PR 	| Title 	| Merges Into 	|   	|
|----	|-------	|-------------	|---	|
|    1	|    [imgixProvider](https://github.com/imgix/react-imgix/pull/791)  	|        [luis/PE-828](https://github.com/imgix/react-imgix/tree/luis/PE-828)    	|   	|
|    2	|    [propsMerger](https://github.com/imgix/react-imgix/pull/790)     	|           #791  	|   	|
|    3	|    [wrapReactImgix](https://github.com/imgix/react-imgix/pull/792)  👈🏼   	|       #790      	|   	|