### PR TITLE
fix(789): ensure children passed to background component update 

### DIFF
--- a/test/unit/should-component-update.test.js
+++ b/test/unit/should-component-update.test.js
@@ -1,0 +1,17 @@
+import { __shouldComponentUpdate } from "../../src/react-imgix-bg"
+
+test("shouldComponentUpdate should return true when children change", () => {
+  const contentRect = { bounds: { width: 100, height: 100 } };
+  const props = { children: 0, contentRect }
+  const nextProps = { children: 1 , contentRect}
+
+  expect(__shouldComponentUpdate(props, nextProps)).toBe(true)
+});
+
+test("shouldComponentUpdate should return false when imgix-params don't change", () => {
+  const contentRect = { bounds: { width: 100, height: 100 } };
+  const props = { contentRect, imgixParams: {ar: "1:2"} }
+  const nextProps = { contentRect, imgixParams: {ar: "1:2"} }
+
+  expect(__shouldComponentUpdate(props, nextProps)).toBe(false)
+});


### PR DESCRIPTION
The `shouldComponentUpdate` function is refactored outside of the `BackgroundImpl` component.

The refactored function, `__shouldComponentUpdate` takes `props` and `nextProps` as arguments. It returns `true` if the `children`, `imgixParams`, `contextRect`, `bounds`, `htmlAttributes`, or top-level `props` have changed. It returns `false` if the props have not changed.

The refactoring addresses an issue where: 
- changes to the children and imgixParams props were not detected
- the child components therefore did not re-render.

``` js
// src/react-imgix-bg.jsx  

// L15
export const __shouldComponentUpdate = (props, nextProps) => {
// ... choose which props to ignore and which ones to compare
  const customizer = (oldProp, newProp, key) => {
    // ... false if children prop has changed
    if (key === "children") {
      return oldProp == newProp;
    }
    // ... false if an imgixParam has changed
    if (key === "imgixParams") {
      return shallowEqual(oldProp, newProp, (a, b) => {
        if (Array.isArray(a)) {
          return shallowEqual(a, b);
        }
        return undefined;
      });
    }
  }
  // ... false if props have changed
  const propsEqual = shallowEqual(props, nextProps, customizer);

  return !(propsEqual);
}
```

This PR closes issue #789.