### PR TITLE
fix: constants out of sync with versions

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = "9.1.2";
+export const PACKAGE_VERSION = "9.1.3";


### PR DESCRIPTION
The most recent release failed to bump the semver. This PR updates the semver from `9.1.2` to `9.1.3`. 