### PR TITLE
build: bump package lock semver which is out of sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "react-imgix",
-  "version": "9.1.4",
+  "version": "9.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "9.1.4",
+      "version": "9.1.5",
       "license": "ISC",
       "dependencies": {
         "@imgix/js-core": "^3.1.3",


### PR DESCRIPTION
I introduced a test-suite failure a few commits back when I bumped this manually after semantic release took "too long". It broke things. ~Hopefully~ this fixes things.