### PR TITLE
docs: update README to include ImgixProvider and domain info

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,42 +335,41 @@ The [`<ImgixProvider>`]() Higher Order Component (HOC), makes [Shared Props](#sh
 For example, by rendering `<ImgixProvider>` at the top level of your application with `imgixParams` defined, all your `<Imgix>` components will have access to the same `imgixParams`.
 
 ```jsx
-import React from 'react'
-import Imgix, { ImgixProvider } from "react-imgix"
-import HomePage from "./components/HomePage"
+import React from "react";
+import Imgix, { ImgixProvider } from "react-imgix";
+import HomePage from "./components/HomePage";
 
 function App() {
-
   return (
     <div className="App">
       <header className="App-header">
         <ImgixProvider imgixParams={{ ar: "16:9" }}>
-          <div className="intro-blurb">
-          {/* ... */}
-          </div>
+          <div className="intro-blurb">{/* ... */}</div>
           <div className="gallery">
-              <Imgix 
-                src="https://assets.imgix.net/examples/pione.jpg"
-              />
-              <Imgix 
-                src="https://sdk-test.imgix.net/ساندویچ.jpg"
-              />
+            <Imgix src="https://assets.imgix.net/examples/pione.jpg" />
+            <Imgix src="https://sdk-test.imgix.net/ساندویچ.jpg" />
           </div>
         </ImgixProvider>
       </header>
     </div>
-  )
+  );
 }
 
-export default App
+export default App;
 ```
 
 So that the generated HTML looks something like
 
 ```html
 <div class="gallery">
-  <img src="https://assets.imgix.net/examples/pione.jpg?auto=format&ar=16%3A9&" .../>
-  <img src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg?auto=format&ar=16%3A9&" .../>
+  <img
+    src="https://assets.imgix.net/examples/pione.jpg?auto=format&ar=16%3A9&"
+    ...
+  />
+  <img
+    src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg?auto=format&ar=16%3A9&"
+    ...
+  />
 </div>
 ```
 
@@ -378,25 +377,30 @@ You can take advantage of this behavior to use 2-step, or partial, URLs with the
 
 ```jsx
 // inside App.jsx
-{/*... */}
+{
+  /*... */
+}
 <ImgixProvider domain="assets.imgix.net">
-  <div className="intro-blurb">
-  {/* ... */}s
-  </div>
+  <div className="intro-blurb">{/* ... */}s</div>
   <div className="gallery">
-      <Imgix src="/examples/pione.jpg" />
-      <Imgix src="/ساندویچ.jpg" />
+    <Imgix src="/examples/pione.jpg" />
+    <Imgix src="/ساندویچ.jpg" />
   </div>
-</ImgixProvider>
-{/*... */}
+</ImgixProvider>;
+{
+  /*... */
+}
 ```
 
 Both the `<Imgix>` components above will access to the `domain` prop from the provider and have their relative `src` paths resolve to the same domain. So that the generated HTML looks something like
 
 ```html
 <div class="gallery">
-  <img src="https://assets.imgix.net/examples/pione.jpg" .../>
-  <img src="https://assets.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg" .../>
+  <img src="https://assets.imgix.net/examples/pione.jpg" ... />
+  <img
+    src="https://assets.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg"
+    ...
+  />
 </div>
 ```
 
@@ -404,28 +408,33 @@ The props that `<ImgixProvider>` makes accessible can also be overridden by `<Im
 
 ```jsx
 // inside App.jsx
-{/*... */}
+{
+  /*... */
+}
 <ImgixProvider imgixParams={{ ar: "16:9" }}>
-  <div className="intro-blurb">
-  {/* ... */}s
-  </div>
+  <div className="intro-blurb">{/* ... */}s</div>
   <div className="gallery">
-      <Imgix
-        imgixParams={ {ar: "4:2"} }
-        src="https://assets.imgix.net/examples/pione.jpg"
-      />
-      <Imgix src="https://sdk-test.imgix.net/ساندویچ.jpg" />
+    <Imgix
+      imgixParams={{ ar: "4:2" }}
+      src="https://assets.imgix.net/examples/pione.jpg"
+    />
+    <Imgix src="https://sdk-test.imgix.net/ساندویچ.jpg" />
   </div>
-</ImgixProvider>
-{/*... */}
+</ImgixProvider>;
+{
+  /*... */
+}
 ```
 
 So that the generated HTML looks something like this
 
 ```html
 <div class="gallery">
-  <img src="https://assets.imgix.net/examples/pione.jpg?ar=4%3A2" .../>
-  <img src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg?ar=16%3A9" .../>
+  <img src="https://assets.imgix.net/examples/pione.jpg?ar=4%3A2" ... />
+  <img
+    src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg?ar=16%3A9"
+    ...
+  />
 </div>
 ```
 
@@ -433,30 +442,30 @@ To remove a shared prop from an `<Imgix>` component, the same prop can be set to
 
 ```jsx
 // inside App.jsx
-{/*... */}
+{
+  /*... */
+}
 <ImgixProvider height={500}>
-  <div className="intro-blurb">
-  {/* ... */}s
-  </div>
+  <div className="intro-blurb">{/* ... */}s</div>
   <div className="gallery">
-      <Imgix
-        src="https://assets.imgix.net/examples/pione.jpg"
-      />
-      <Imgix
-        height={undefined}
-        src="https://sdk-test.imgix.net/ساندویچ.jpg"
-      />
+    <Imgix src="https://assets.imgix.net/examples/pione.jpg" />
+    <Imgix height={undefined} src="https://sdk-test.imgix.net/ساندویچ.jpg" />
   </div>
-</ImgixProvider>
-{/*... */}
+</ImgixProvider>;
+{
+  /*... */
+}
 ```
 
 So that the generated HTML looks something like this
 
 ```html
 <div class="gallery">
-  <img src="https://assets.imgix.net/examples/pione.jpg?h=500" .../>
-  <img src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg" .../>
+  <img src="https://assets.imgix.net/examples/pione.jpg?h=500" ... />
+  <img
+    src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg"
+    ...
+  />
 </div>
 ```
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ function App() {
   return (
     <div className="App">
       <header className="App-header">
-        <ImgixProvider imgixParams={{ ar: "16:9" }}>
+        <ImgixProvider imgixParams={{ ar: "16:9", fit: "crop" }}>
           <div className="intro-blurb">{/* ... */}</div>
           <div className="gallery">
             <Imgix src="https://assets.imgix.net/examples/pione.jpg" />
@@ -361,11 +361,11 @@ So that the generated HTML looks something like
 ```html
 <div class="gallery">
   <img
-    src="https://assets.imgix.net/examples/pione.jpg?auto=format&ar=16%3"
+    src="https://assets.imgix.net/examples/pione.jpg?auto=format&ar=16%3A9&fit=crop"
     ...
   />
   <img
-    src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg?auto=format&ar=16%3"
+    src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg?auto=format&ar=16%3A9&fit=crop"
     ...
   />
 </div>
@@ -409,7 +409,7 @@ The props that `<ImgixProvider>` makes accessible can also be overridden by `<Im
 {
   /*... */
 }
-<ImgixProvider imgixParams={{ ar: "16:9" }}>
+<ImgixProvider imgixParams={{ ar: "16:9", fit:"crop" }}>
   <div className="intro-blurb">{/* ... */}s</div>
   <div className="gallery">
     <Imgix
@@ -428,9 +428,12 @@ So that the generated HTML looks something like this
 
 ```html
 <div class="gallery">
-  <img src="https://assets.imgix.net/examples/pione.jpg?ar=4%3A2" ... />
   <img
-    src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg?ar=16%3A9"
+    src="https://assets.imgix.net/examples/pione.jpg?auto=format&ar=4%3A2&fit=crop"
+    ...
+  />
+  <img
+    src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg?ar=16%3A9&fit=crop"
     ...
   />
 </div>

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ You can take advantage of this behavior to use partial URLs with the `<Imgix>` c
 }
 ```
 
-Both the `<Imgix>` components above will access to the `domain` prop from the provider and have their relative `src` paths resolve to the same domain. So that the generated HTML looks something like
+Both the `<Imgix>` components above will access to the `domain` prop from the provider and have their relative `src` paths resolve to the same domain. So that the generated HTML looks something like:
 
 ```html
 <div class="gallery">
@@ -455,7 +455,7 @@ To remove a shared prop from an `<Imgix>` component, the same prop can be set to
 }
 ```
 
-So that the generated HTML looks something like this
+So that the generated HTML looks something like this:
 
 ```html
 <div class="gallery">
@@ -467,9 +467,9 @@ So that the generated HTML looks something like this
 </div>
 ```
 
-You cans nest `ImgixProvider` components to ensure that different consumers have different props.
+You can nest `ImgixProvider` components to ensure that different consumers have different props.
 
-For example to give `Imgix` components different props from `Picture` components, you can next an `ImgixProvider` inside of another one.
+For example to give `Imgix` components different props from `Picture` components, you can nest an `ImgixProvider` inside of another one.
 
 The nested Provider will change the Context for the `Picture` component, essentially removing their access to the shared props provided by the root `ImgixProvider`.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
         + [Fixed Image Rendering (i.e. non-flexible)](#fixed-image-rendering-ie-non-flexible)
         + [Background Mode](#background-mode)
         + [Picture Support](#picture-support)
-        + [ImgixProvider Component ✨](#imgixprovider-component)
+        + [ImgixProvider Component](#imgixprovider-component)
     * [Advanced Examples](#advanced-examples)
         + [General Advanced Usage](#general-advanced-usage)
         + [Passing Custom HTML Attributes](#passing-custom-html-attributes)
@@ -328,9 +328,7 @@ A warning is displayed when no fallback image is passed. This warning can be dis
 
 #### ImgixProvider Component
 
-> New 🪄 ✨
-
-The [`<ImgixProvider>`]() Higher Order Component (HOC), makes its [props](#props) available to any nested `<Imgix>` component in your React application.
+The `<ImgixProvider>` Higher Order Component (HOC), makes its [props](#props) available to any nested `<Imgix>` component in your React application.
 
 For example, by rendering `<ImgixProvider>` at the top level of your application with `imgixParams` defined, all your `<Imgix>` components will have access to the same `imgixParams`.
 
@@ -363,17 +361,17 @@ So that the generated HTML looks something like
 ```html
 <div class="gallery">
   <img
-    src="https://assets.imgix.net/examples/pione.jpg?auto=format&ar=16%3A9&"
+    src="https://assets.imgix.net/examples/pione.jpg?auto=format&ar=16%3"
     ...
   />
   <img
-    src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg?auto=format&ar=16%3A9&"
+    src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg?auto=format&ar=16%3"
     ...
   />
 </div>
 ```
 
-You can take advantage of this behavior to use 2-step, or partial, URLs with the `<Imgix>` component. By defining the [`domain`](#domain--string-optional) prop on the Provider, it can be made accessible to all nested `<Imgix>` components.
+You can take advantage of this behavior to use partial URLs with the `<Imgix>` component. By defining the [`domain`](#domain--string-optional) prop on the Provider, it can be made accessible to all nested `<Imgix>` components.
 
 ```jsx
 // inside App.jsx
@@ -384,7 +382,7 @@ You can take advantage of this behavior to use 2-step, or partial, URLs with the
   <div className="intro-blurb">{/* ... */}s</div>
   <div className="gallery">
     <Imgix src="/examples/pione.jpg" />
-    <Imgix src="/ساندویچ.jpg" />
+    <Imgix src="Office Background 1.png" />
   </div>
 </ImgixProvider>;
 {
@@ -398,7 +396,7 @@ Both the `<Imgix>` components above will access to the `domain` prop from the pr
 <div class="gallery">
   <img src="https://assets.imgix.net/examples/pione.jpg" ... />
   <img
-    src="https://assets.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg"
+    src="https://assets.imgix.net/Office%20Background%201.png?auto=format"
     ...
   />
 </div>
@@ -614,7 +612,7 @@ Usually in the form: `https://[your_domain].imgix.net/[image]`. Don't include an
 
 ##### domain :: string, optional
 
-Required only when using 2-step, partial, paths as `src` prop for a component. IE, if `src` is `"/images/myImage.jpg"`, then the `domain` prop needs to be defined.
+Required only when using partial paths as `src` prop for a component. IE, if `src` is `"/images/myImage.jpg"`, then the `domain` prop needs to be defined.
 
 _For example_:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
         + [Fixed Image Rendering (i.e. non-flexible)](#fixed-image-rendering-ie-non-flexible)
         + [Background Mode](#background-mode)
         + [Picture Support](#picture-support)
+        + [ImgixProvider Component ✨](#imgixprovider-component)
     * [Advanced Examples](#advanced-examples)
         + [General Advanced Usage](#general-advanced-usage)
         + [Passing Custom HTML Attributes](#passing-custom-html-attributes)
@@ -325,6 +326,140 @@ const commonProps = {
 
 A warning is displayed when no fallback image is passed. This warning can be disabled in special circumstances. To disable this warning, look in the [warnings section](#warnings).
 
+#### ImgixProvider Component
+
+> New 🪄 ✨
+
+The [`<ImgixProvider>`]() Higher Order Component (HOC), makes [Shared Props](#shared-props-imgix-source) available to any nested `<Imgix>` component in your React application.
+
+For example, by rendering `<ImgixProvider>` at the top level of your application with `imgixParams` defined, all your `<Imgix>` components will have access to the same `imgixParams`.
+
+```jsx
+import React from 'react'
+import Imgix, { ImgixProvider } from "react-imgix"
+import HomePage from "./components/HomePage"
+
+function App() {
+
+  return (
+    <div className="App">
+      <header className="App-header">
+        <ImgixProvider imgixParams={{ ar: "16:9" }}>
+          <div className="intro-blurb">
+          {/* ... */}
+          </div>
+          <div className="gallery">
+              <Imgix 
+                src="https://assets.imgix.net/examples/pione.jpg"
+              />
+              <Imgix 
+                src="https://sdk-test.imgix.net/ساندویچ.jpg"
+              />
+          </div>
+        </ImgixProvider>
+      </header>
+    </div>
+  )
+}
+
+export default App
+```
+
+So that the generated HTML looks something like
+
+```html
+<div class="gallery">
+  <img src="https://assets.imgix.net/examples/pione.jpg?auto=format&ar=16%3A9&" .../>
+  <img src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg?auto=format&ar=16%3A9&" .../>
+</div>
+```
+
+You can take advantage of this behavior to use 2-step, or partial, URLs with the `<Imgix>` component. By defining the [`domain`](#domain--string-optional) prop on the Provider, it can be made accessible to all nested `<Imgix>` components.
+
+```jsx
+// inside App.jsx
+{/*... */}
+<ImgixProvider domain="assets.imgix.net">
+  <div className="intro-blurb">
+  {/* ... */}s
+  </div>
+  <div className="gallery">
+      <Imgix src="/examples/pione.jpg" />
+      <Imgix src="/ساندویچ.jpg" />
+  </div>
+</ImgixProvider>
+{/*... */}
+```
+
+Both the `<Imgix>` components above will access to the `domain` prop from the provider and have their relative `src` paths resolve to the same domain. So that the generated HTML looks something like
+
+```html
+<div class="gallery">
+  <img src="https://assets.imgix.net/examples/pione.jpg" .../>
+  <img src="https://assets.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg" .../>
+</div>
+```
+
+The props that `<ImgixProvider>` makes accessible can also be overridden by `<Imgix>` components. Any prop defined on the `<Imgix>` component will override the value set by the Provider.
+
+```jsx
+// inside App.jsx
+{/*... */}
+<ImgixProvider imgixParams={{ ar: "16:9" }}>
+  <div className="intro-blurb">
+  {/* ... */}s
+  </div>
+  <div className="gallery">
+      <Imgix
+        imgixParams={ {ar: "4:2"} }
+        src="https://assets.imgix.net/examples/pione.jpg"
+      />
+      <Imgix src="https://sdk-test.imgix.net/ساندویچ.jpg" />
+  </div>
+</ImgixProvider>
+{/*... */}
+```
+
+So that the generated HTML looks something like this
+
+```html
+<div class="gallery">
+  <img src="https://assets.imgix.net/examples/pione.jpg?ar=4%3A2" .../>
+  <img src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg?ar=16%3A9" .../>
+</div>
+```
+
+To remove a shared prop from an `<Imgix>` component, the same prop can be set to `undefined` on the component itself.
+
+```jsx
+// inside App.jsx
+{/*... */}
+<ImgixProvider height={500}>
+  <div className="intro-blurb">
+  {/* ... */}s
+  </div>
+  <div className="gallery">
+      <Imgix
+        src="https://assets.imgix.net/examples/pione.jpg"
+      />
+      <Imgix
+        height={undefined}
+        src="https://sdk-test.imgix.net/ساندویچ.jpg"
+      />
+  </div>
+</ImgixProvider>
+{/*... */}
+```
+
+So that the generated HTML looks something like this
+
+```html
+<div class="gallery">
+  <img src="https://assets.imgix.net/examples/pione.jpg?h=500" .../>
+  <img src="https://sdk-test.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg" .../>
+</div>
+```
+
 ### Advanced Examples
 
 #### General Advanced Usage
@@ -425,6 +560,16 @@ These props are shared among Imgix and Source Components
 ##### src :: string, required
 
 Usually in the form: `https://[your_domain].imgix.net/[image]`. Don't include any parameters.
+
+##### domain :: string, optional
+
+Required only when using 2-step, partial, paths as `src` prop for a component. IE, if `src` is `"/images/myImage.jpg"`, then the `domain` prop needs to be defined.
+
+_For example_:
+
+```jsx
+<Imgix domain="assets.imgix.net" src="/examples/pione.jpg">
+```
 
 ##### imgixParams :: object
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ A warning is displayed when no fallback image is passed. This warning can be dis
 
 > New 🪄 ✨
 
-The [`<ImgixProvider>`]() Higher Order Component (HOC), makes [Shared Props](#shared-props-imgix-source) available to any nested `<Imgix>` component in your React application.
+The [`<ImgixProvider>`]() Higher Order Component (HOC), makes its [props](#props) available to any nested `<Imgix>` component in your React application.
 
 For example, by rendering `<ImgixProvider>` at the top level of your application with `imgixParams` defined, all your `<Imgix>` components will have access to the same `imgixParams`.
 
@@ -467,6 +467,48 @@ So that the generated HTML looks something like this
     ...
   />
 </div>
+```
+
+You cans nest `ImgixProvider` components to ensure that different consumers have different props.
+
+For example to give `Imgix` components different props from `Picture` components, you can next an `ImgixProvider` inside of another one.
+
+The nested Provider will change the Context for the `Picture` component, essentially removing their access to the shared props provided by the root `ImgixProvider`.
+
+```jsx
+import React from 'react'
+import Imgix, { ImgixProvider, Picture, Source } from "react-imgix";
+export default function simpleImage() {
+  return (
+    <div className="imgix-simple-api-example">
+      {/* there props will be accessible to all the imgix components */}
+      <ImgixProvider
+        domain="assets.imgix.net"
+        src="/examples/pione.jpg"
+        imgixParams={{ fit: "crop" }}
+      >
+        <Imgix width={200} height={500} src="/examples/pione.jpg" />
+        <Imgix domain="sdk-test.imgix.net" src="/ساندویچ.jpg" />
+        <ImgixProvider
+          {/* since we define a new provider here, the context is redefined for any child components */}
+        >
+          <Picture>
+            {/* imgixParams prop is no longer defined here */}
+            <Source
+              width={100}
+              htmlAttributes={{ media: "(min-width: 768px)" }}
+            />
+            <Source
+              width={200}
+              htmlAttributes={{ media: "(min-width: 800px)" }}
+            />
+            <Imgix src="/examples/pione.jpg" />
+          </Picture>
+        </ImgixProvider>
+      </ImgixProvider>
+    </div>
+  )
+}
 ```
 
 ### Advanced Examples


### PR DESCRIPTION
This PR updates `README.md` to include documentation for the new ✨ `<ImgixProvider>` HOC and `domain` prop.