### PR TITLE
chore: fix deprecated tests

### DIFF
--- a/test/unit/find-closest.test.js
+++ b/test/unit/find-closest.test.js
@@ -4,10 +4,10 @@ test("when closest value is below the search value", () =>
   expect(findClosest(101, [100, 200])).toBe(100));
 test("when closest value is above the search value", () =>
   expect(findClosest(151, [100, 200])).toBe(200));
-test.only("when closest value is the median of two nearest values, the largest value is returned", () =>
+test("when closest value is the median of two nearest values, the largest value is returned", () =>
   expect(findClosest(150, [100, 200])).toBe(200));
 
-test("Edge cases", () => {
+describe("Edge cases", () => {
   test("when value is smaller than the entire array", () =>
     expect(findClosest(80, [100, 200])).toBe(100));
   test("when value is larger than the entire array", () =>

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -443,21 +443,6 @@ describe("When in picture mode", () => {
     it("only one child should exist", () => {
       expect(children).toHaveLength(1);
     });
-    it.skip("props should not be passed down to children", () => {
-      expect(
-        lastChild
-          .first()
-          .shallow() // hack from https://github.com/airbnb/enzyme/issues/539#issuecomment-239497107 until a better solution is implemented
-          .props()
-      ).toMatchObject({
-        imgixParams: {
-          crop: "faces",
-        },
-        htmlAttributes: {
-          alt: childAlt,
-        },
-      });
-    });
   });
 
   describe("with an <img> passed as a child", () => {


### PR DESCRIPTION
This PR fixes one and removes another test that had gotten out of sync with the code base.

In the case of `test/unit/react-imgix.test.jsx`, the removed test has been skipped for years and is assumed to be no longer relevant.