### PR TITLE
test: automatically update browserlist capabilities for karma testing

### DIFF
--- a/config/karma/karmaConfig.js
+++ b/config/karma/karmaConfig.js
@@ -13,7 +13,7 @@ const baseConfig = {
     "karma-chrome-launcher",
   ],
   preprocessors: {
-    "../../test/tests.webpack.js": "webpack"
+    "../../test/tests.webpack.js": "webpack",
   },
   reporters: ["mocha"],
   captureTimeout: 100000,
@@ -21,26 +21,26 @@ const baseConfig = {
   browserNoActivityTimeout: 60000,
   webpack: webpackConfig,
   webpackMiddleware: {},
-  concurrency: 5
+  concurrency: 5,
 };
 
 /**
  * Local testing - headless browsers
  */
 
-const headlessConfig = karmaConfig => {
+const headlessConfig = (karmaConfig) => {
   process.env.CHROME_BIN = require("puppeteer").executablePath();
   const headlessConfig = {
     ...baseConfig,
     browsers: ["ChromeHeadless"],
     webpack: {
       ...baseConfig.webpack,
-      stats: "errors-only"
+      stats: "errors-only",
     },
     webpackMiddleware: {
       ...baseConfig.webpackMiddleware,
-      stats: "errors-only"
-    }
+      stats: "errors-only",
+    },
   };
   karmaConfig.set(headlessConfig);
 };
@@ -49,11 +49,11 @@ const headlessConfig = karmaConfig => {
  * Local testing - full browsers
  */
 
-const localConfig = karmaConfig => {
+const localConfig = (karmaConfig) => {
   const browsers = [
     "ChromeHeadless",
     "FirefoxHeadless",
-    ...(process.platform === "darwin" ? ["Safari"] : [])
+    ...(process.platform === "darwin" ? ["Safari"] : []),
   ];
   karmaConfig.set({
     ...baseConfig,
@@ -61,18 +61,18 @@ const localConfig = karmaConfig => {
     customLaunchers: {
       FirefoxHeadless: {
         base: "Firefox",
-        flags: ["-headless"]
-      }
+        flags: ["-headless"],
+      },
     },
 
     webpack: {
       ...baseConfig.webpack,
-      stats: "errors-only"
+      stats: "errors-only",
     },
     webpackMiddleware: {
       ...baseConfig.webpackMiddleware,
-      stats: "errors-only"
-    }
+      stats: "errors-only",
+    },
   });
 };
 
@@ -80,7 +80,7 @@ const localConfig = karmaConfig => {
  * CI testing - Chrome, Firefox, and (if available) BrowserStack
  */
 
-const headlessConfigCI = karmaConfig => {
+const headlessConfigCI = (karmaConfig) => {
   const config = {
     ...baseConfig,
     reporters: [...baseConfig.reporters],
@@ -88,19 +88,19 @@ const headlessConfigCI = karmaConfig => {
     customLaunchers: {
       ChromeTravis: {
         base: "ChromeHeadless",
-        flags: ["--no-sandbox"]
+        flags: ["--no-sandbox"],
       },
       FirefoxHeadless: {
         base: "Firefox",
-        flags: ["-headless"]
-      }
+        flags: ["-headless"],
+      },
     },
     plugins: [...baseConfig.plugins],
     client: {
       mocha: {
-        timeout: 20000 // 20 seconds
-      }
-    }
+        timeout: 20000, // 20 seconds
+      },
+    },
   };
 
   karmaConfig.set(config);
@@ -164,7 +164,7 @@ const fullConfig = async (karmaConfig) => {
   console.log(`Using BrowserStack custom browsers: ${customBSLaunchers}`);
 
   const bsBrowsersWithoutChromeAndFirefox = bsBrowsers.filter(
-    browser => !(browser.includes("chrome") || browser.includes("firefox"))
+    (browser) => !(browser.includes("chrome") || browser.includes("firefox"))
   );
 
   const config = {
@@ -184,14 +184,14 @@ const fullConfig = async (karmaConfig) => {
     plugins: [...baseConfig.plugins, "karma-browserstack-launcher"],
     client: {
       mocha: {
-        timeout: 20000 // 20 seconds
-      }
-    }
+        timeout: 20000, // 20 seconds
+      },
+    },
   };
 
   console.log(
     "Testing on browsers:\n",
-    config.browsers.map(browser => ` - ${browser}`).join("\n")
+    config.browsers.map((browser) => ` - ${browser}`).join("\n")
   );
 
   karmaConfig.set(config);

--- a/config/karma/karmaConfig.js
+++ b/config/karma/karmaConfig.js
@@ -126,7 +126,7 @@ const formatForKarma = (capabilities, browserBase) => {
 };
 
 const mapBrowsersListToBrowserStackLaunchers = async () => {
-  return await browserList_browserStack // nosonar
+  return await browserList_browserStack
     .default({
       username: process.env.BROWSERSTACK_USERNAME,
       accessKey: process.env.BROWSERSTACK_ACCESS_KEY,

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "babel-plugin-inline-package-json": "2.0.0",
         "babel-plugin-transform-es2017-object-entries": "0.0.5",
         "browserslist": "4.7.0",
+        "browserslist-browserstack": "^3.1.1",
         "common-tags": "1.8.0",
         "conventional-changelog-conventionalcommits": "4.6.0",
         "cross-env": "7.0.3",
@@ -93,6 +94,8 @@
       "integrity": "sha512-eRJREyrfAJ2r42Iaxe8h3v6yyj1wu9OyosaUHW6UImjGf9ahGL9nsFNh7OCopvtcPL8WnEo7tp78wrZaZ6vG9g==",
       "dev": true,
       "dependencies": {
+        "@nicolo-ribaudo/chokidar-2": "^2.1.8",
+        "chokidar": "^3.4.0",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
@@ -631,24 +634,6 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/caniuse-lite": {
-      "version": "1.0.30001148",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
-      "integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==",
-      "dev": true
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/electron-to-chromium": {
-      "version": "1.3.581",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.581.tgz",
-      "integrity": "sha512-ALORbI23YkYJoVJWusSdmTq8vXH3TLFzniILE47uZkZOim135ZhoTCM7QlIuvmK78As5kLdANfy7kDIQvJ+iPw==",
-      "dev": true
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/node-releases": {
-      "version": "1.1.63",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.63.tgz",
-      "integrity": "sha512-ukW3iCfQaoxJkSPN+iK7KznTeqDGVJatAEuXsJERYHa9tn/KaT5lBdIyxQjLEVTzSkyjJEuQ17/vaEjrOauDkg==",
-      "dev": true
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.12.1",
@@ -5087,6 +5072,7 @@
         "jest-resolve": "^25.5.1",
         "jest-util": "^25.5.0",
         "jest-worker": "^25.5.0",
+        "node-notifier": "^6.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^3.1.0",
@@ -6024,6 +6010,7 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -6506,6 +6493,7 @@
       "dev": true,
       "peer": true,
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -6689,6 +6677,7 @@
       "dev": true,
       "peer": true,
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -9691,6 +9680,42 @@
         "browserslist": "cli.js"
       }
     },
+    "node_modules/browserslist-browserstack": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/browserslist-browserstack/-/browserslist-browserstack-3.1.1.tgz",
+      "integrity": "sha512-iKFpdr6tQvZJn1tAF/cCqWIcm7xDpiP17hFuntMKRfWCzLO2WC+tNwM5pWgHY4ktvwvL9OaDI9rjVcuQ3YDpHg==",
+      "dev": true,
+      "dependencies": {
+        "browserslist": "^4.14.7",
+        "node-fetch": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/browserslist-browserstack/node_modules/browserslist": {
+      "version": "4.16.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+      "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+      "dev": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001251",
+        "colorette": "^1.3.0",
+        "electron-to-chromium": "^1.3.811",
+        "escalade": "^3.1.1",
+        "node-releases": "^1.1.75"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
     "node_modules/browserstack": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.3.tgz",
@@ -9924,10 +9949,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30000989",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-      "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
-      "dev": true
+      "version": "1.0.30001251",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -10018,6 +10047,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -10325,9 +10355,9 @@
       "dev": true
     },
     "node_modules/colorette": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
       "dev": true
     },
     "node_modules/colors": {
@@ -11216,24 +11246,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/core-js-compat/node_modules/caniuse-lite": {
-      "version": "1.0.30001148",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
-      "integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==",
-      "dev": true
-    },
-    "node_modules/core-js-compat/node_modules/electron-to-chromium": {
-      "version": "1.3.581",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.581.tgz",
-      "integrity": "sha512-ALORbI23YkYJoVJWusSdmTq8vXH3TLFzniILE47uZkZOim135ZhoTCM7QlIuvmK78As5kLdANfy7kDIQvJ+iPw==",
-      "dev": true
-    },
-    "node_modules/core-js-compat/node_modules/node-releases": {
-      "version": "1.1.63",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.63.tgz",
-      "integrity": "sha512-ukW3iCfQaoxJkSPN+iK7KznTeqDGVJatAEuXsJERYHa9tn/KaT5lBdIyxQjLEVTzSkyjJEuQ17/vaEjrOauDkg==",
-      "dev": true
-    },
     "node_modules/core-js-compat/node_modules/semver": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
@@ -12105,9 +12117,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.247",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.247.tgz",
-      "integrity": "sha512-j/Rzx1FyVTwNifpG/DPQKEMz0mruRwoPpJ6Y1tTVmj6+/zAVzG8/YHZwBMLYCZgQH6seLOqaVxZ3RY3KMrT5IQ==",
+      "version": "1.3.814",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.814.tgz",
+      "integrity": "sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -12610,7 +12622,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -13306,6 +13319,7 @@
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "dependencies": {
+        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -13996,6 +14010,8 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14003,6 +14019,8 @@
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14013,6 +14031,8 @@
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14020,6 +14040,8 @@
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14031,6 +14053,8 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14038,6 +14062,8 @@
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14049,6 +14075,8 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14056,6 +14084,8 @@
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14066,6 +14096,8 @@
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14073,6 +14105,8 @@
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14080,6 +14114,8 @@
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14087,6 +14123,8 @@
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14097,6 +14135,8 @@
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14107,6 +14147,8 @@
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14114,6 +14156,8 @@
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -14127,6 +14171,8 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14137,6 +14183,8 @@
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14144,6 +14192,8 @@
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14161,6 +14211,8 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14179,6 +14231,8 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14186,6 +14240,8 @@
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14199,6 +14255,8 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14209,6 +14267,8 @@
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14220,6 +14280,8 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14227,6 +14289,8 @@
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14237,6 +14301,8 @@
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14250,6 +14316,8 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14257,6 +14325,8 @@
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14270,6 +14340,8 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14277,6 +14349,8 @@
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14288,6 +14362,8 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14298,6 +14374,8 @@
     },
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14311,6 +14389,8 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14318,6 +14398,8 @@
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+      "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14336,6 +14418,8 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+      "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -14358,6 +14442,8 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14372,6 +14458,8 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14379,6 +14467,8 @@
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14390,6 +14480,8 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14403,6 +14495,8 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14413,6 +14507,8 @@
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14423,6 +14519,8 @@
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14433,6 +14531,8 @@
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14443,6 +14543,8 @@
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14453,6 +14555,8 @@
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14464,6 +14568,8 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14474,6 +14580,8 @@
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14481,6 +14589,8 @@
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
@@ -14497,6 +14607,8 @@
     },
     "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14504,6 +14616,8 @@
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14520,6 +14634,8 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14533,6 +14649,8 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14540,6 +14658,8 @@
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14547,6 +14667,8 @@
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14554,6 +14676,8 @@
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14564,6 +14688,8 @@
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14571,6 +14697,8 @@
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14578,6 +14706,8 @@
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14588,6 +14718,8 @@
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14603,6 +14735,8 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14616,6 +14750,8 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14626,6 +14762,8 @@
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14645,6 +14783,8 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14652,6 +14792,8 @@
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14662,6 +14804,8 @@
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -14669,6 +14813,8 @@
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -15269,6 +15415,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -17614,6 +17761,7 @@
         "@types/graceful-fs": "^4.1.2",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-serializer": "^25.5.0",
         "jest-util": "^25.5.0",
@@ -21284,6 +21432,7 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -22724,6 +22873,7 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -23465,13 +23615,10 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.29.tgz",
-      "integrity": "sha512-R5bDhzh6I+tpi/9i2hrrvGJ3yKPYzlVOORDkXhnZuwi5D3q1I5w4vYy24PJXTcLk9Q0kws9TO77T75bcK8/ysQ==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^5.3.0"
-      }
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+      "dev": true
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -24020,6 +24167,8 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24027,6 +24176,8 @@
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24040,6 +24191,8 @@
     },
     "node_modules/npm/node_modules/agentkeepalive": {
       "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+      "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24053,6 +24206,8 @@
     },
     "node_modules/npm/node_modules/ansi-align": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24063,6 +24218,8 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24073,6 +24230,8 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24086,6 +24245,8 @@
     },
     "node_modules/npm/node_modules/ansicolors": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24093,6 +24254,8 @@
     },
     "node_modules/npm/node_modules/ansistyles": {
       "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+      "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24100,6 +24263,8 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24107,6 +24272,8 @@
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24114,6 +24281,8 @@
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24125,6 +24294,8 @@
     },
     "node_modules/npm/node_modules/are-we-there-yet/node_modules/readable-stream": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24141,6 +24312,8 @@
     },
     "node_modules/npm/node_modules/are-we-there-yet/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24151,6 +24324,8 @@
     },
     "node_modules/npm/node_modules/asap": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24158,6 +24333,8 @@
     },
     "node_modules/npm/node_modules/asn1": {
       "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24168,6 +24345,8 @@
     },
     "node_modules/npm/node_modules/assert-plus": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24178,6 +24357,8 @@
     },
     "node_modules/npm/node_modules/asynckit": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24185,6 +24366,8 @@
     },
     "node_modules/npm/node_modules/aws-sign2": {
       "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -24195,6 +24378,8 @@
     },
     "node_modules/npm/node_modules/aws4": {
       "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24202,6 +24387,8 @@
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24209,6 +24396,8 @@
     },
     "node_modules/npm/node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -24220,6 +24409,8 @@
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.8.tgz",
+      "integrity": "sha512-KgmVfx+QqggqP9dA3iIc5pA4T1qEEEL+hOhOhNPaUm77OTrJoOXE/C05SJLNJe6m/2wUK7F1tDSou7n5TfCDzQ==",
       "dev": true,
       "inBundle": true,
       "license": "Artistic-2.0",
@@ -24235,6 +24426,8 @@
     },
     "node_modules/npm/node_modules/bluebird": {
       "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24242,6 +24435,8 @@
     },
     "node_modules/npm/node_modules/boxen": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24261,6 +24456,8 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24272,6 +24469,8 @@
     },
     "node_modules/npm/node_modules/buffer-from": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24279,6 +24478,8 @@
     },
     "node_modules/npm/node_modules/builtins": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24286,6 +24487,8 @@
     },
     "node_modules/npm/node_modules/byline": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24296,6 +24499,8 @@
     },
     "node_modules/npm/node_modules/byte-size": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz",
+      "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24306,6 +24511,8 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+      "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24330,6 +24537,8 @@
     },
     "node_modules/npm/node_modules/call-limit": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.1.tgz",
+      "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24337,6 +24546,8 @@
     },
     "node_modules/npm/node_modules/camelcase": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24347,6 +24558,8 @@
     },
     "node_modules/npm/node_modules/capture-stack-trace": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24357,6 +24570,8 @@
     },
     "node_modules/npm/node_modules/caseless": {
       "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -24364,6 +24579,8 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24379,6 +24596,8 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24386,6 +24605,8 @@
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24393,6 +24614,8 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.10.tgz",
+      "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -24406,6 +24629,8 @@
     },
     "node_modules/npm/node_modules/cli-boxes": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24416,6 +24641,8 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
+      "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24430,11 +24657,14 @@
     },
     "node_modules/npm/node_modules/cli-table3": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
+        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^2.1.1"
       },
@@ -24447,6 +24677,8 @@
     },
     "node_modules/npm/node_modules/cliui": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24459,6 +24691,8 @@
     },
     "node_modules/npm/node_modules/cliui/node_modules/ansi-regex": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24469,6 +24703,8 @@
     },
     "node_modules/npm/node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24479,6 +24715,8 @@
     },
     "node_modules/npm/node_modules/cliui/node_modules/string-width": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24494,6 +24732,8 @@
     },
     "node_modules/npm/node_modules/cliui/node_modules/strip-ansi": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24507,6 +24747,8 @@
     },
     "node_modules/npm/node_modules/clone": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24517,6 +24759,8 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-3.0.3.tgz",
+      "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24528,6 +24772,8 @@
     },
     "node_modules/npm/node_modules/code-point-at": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24538,6 +24784,8 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24548,6 +24796,8 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24555,6 +24805,8 @@
     },
     "node_modules/npm/node_modules/colors": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24566,6 +24818,8 @@
     },
     "node_modules/npm/node_modules/columnify": {
       "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+      "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24577,6 +24831,8 @@
     },
     "node_modules/npm/node_modules/combined-stream": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24590,6 +24846,8 @@
     },
     "node_modules/npm/node_modules/concat-map": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24597,6 +24855,8 @@
     },
     "node_modules/npm/node_modules/concat-stream": {
       "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "engines": [
         "node >= 0.8"
@@ -24613,6 +24873,8 @@
     },
     "node_modules/npm/node_modules/concat-stream/node_modules/readable-stream": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24629,6 +24891,8 @@
     },
     "node_modules/npm/node_modules/concat-stream/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24639,6 +24903,8 @@
     },
     "node_modules/npm/node_modules/config-chain": {
       "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "dev": true,
       "inBundle": true,
       "peer": true,
@@ -24649,6 +24915,8 @@
     },
     "node_modules/npm/node_modules/configstore": {
       "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.5.tgz",
+      "integrity": "sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -24667,6 +24935,8 @@
     },
     "node_modules/npm/node_modules/console-control-strings": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24674,6 +24944,8 @@
     },
     "node_modules/npm/node_modules/copy-concurrently": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24689,6 +24961,8 @@
     },
     "node_modules/npm/node_modules/copy-concurrently/node_modules/aproba": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24696,6 +24970,8 @@
     },
     "node_modules/npm/node_modules/copy-concurrently/node_modules/iferr": {
       "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24703,6 +24979,8 @@
     },
     "node_modules/npm/node_modules/core-util-is": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24710,6 +24988,8 @@
     },
     "node_modules/npm/node_modules/create-error-class": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24723,6 +25003,8 @@
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24735,6 +25017,8 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/lru-cache": {
       "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24746,6 +25030,8 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/yallist": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24753,6 +25039,8 @@
     },
     "node_modules/npm/node_modules/crypto-random-string": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24763,12 +25051,16 @@
     },
     "node_modules/npm/node_modules/cyclist": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true,
       "inBundle": true,
       "peer": true
     },
     "node_modules/npm/node_modules/dashdash": {
       "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24782,6 +25074,8 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24792,6 +25086,8 @@
     },
     "node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24799,6 +25095,8 @@
     },
     "node_modules/npm/node_modules/debuglog": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24809,6 +25107,8 @@
     },
     "node_modules/npm/node_modules/decamelize": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24819,6 +25119,8 @@
     },
     "node_modules/npm/node_modules/decode-uri-component": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24829,6 +25131,8 @@
     },
     "node_modules/npm/node_modules/deep-extend": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24839,6 +25143,8 @@
     },
     "node_modules/npm/node_modules/defaults": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24849,6 +25155,8 @@
     },
     "node_modules/npm/node_modules/define-properties": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24862,6 +25170,8 @@
     },
     "node_modules/npm/node_modules/delayed-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24872,6 +25182,8 @@
     },
     "node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24879,6 +25191,8 @@
     },
     "node_modules/npm/node_modules/detect-indent": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+      "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24889,6 +25203,8 @@
     },
     "node_modules/npm/node_modules/detect-newline": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24899,6 +25215,8 @@
     },
     "node_modules/npm/node_modules/dezalgo": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -24910,6 +25228,8 @@
     },
     "node_modules/npm/node_modules/dot-prop": {
       "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+      "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24923,6 +25243,8 @@
     },
     "node_modules/npm/node_modules/dotenv": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -24933,6 +25255,8 @@
     },
     "node_modules/npm/node_modules/duplexer3": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -24940,6 +25264,8 @@
     },
     "node_modules/npm/node_modules/duplexify": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24953,6 +25279,8 @@
     },
     "node_modules/npm/node_modules/duplexify/node_modules/readable-stream": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24969,6 +25297,8 @@
     },
     "node_modules/npm/node_modules/duplexify/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24979,6 +25309,8 @@
     },
     "node_modules/npm/node_modules/ecc-jsbn": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24991,6 +25323,8 @@
     },
     "node_modules/npm/node_modules/editor": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+      "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -24998,6 +25332,8 @@
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25005,6 +25341,8 @@
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25015,6 +25353,8 @@
     },
     "node_modules/npm/node_modules/end-of-stream": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25025,6 +25365,8 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25035,6 +25377,8 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25042,6 +25386,8 @@
     },
     "node_modules/npm/node_modules/errno": {
       "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25055,6 +25401,8 @@
     },
     "node_modules/npm/node_modules/es-abstract": {
       "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25072,6 +25420,8 @@
     },
     "node_modules/npm/node_modules/es-to-primitive": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25087,6 +25437,8 @@
     },
     "node_modules/npm/node_modules/es6-promise": {
       "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25094,6 +25446,8 @@
     },
     "node_modules/npm/node_modules/es6-promisify": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25104,6 +25458,8 @@
     },
     "node_modules/npm/node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25114,6 +25470,8 @@
     },
     "node_modules/npm/node_modules/execa": {
       "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25133,6 +25491,8 @@
     },
     "node_modules/npm/node_modules/execa/node_modules/get-stream": {
       "version": "3.0.0",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25143,6 +25503,8 @@
     },
     "node_modules/npm/node_modules/extend": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25150,6 +25512,8 @@
     },
     "node_modules/npm/node_modules/extsprintf": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -25160,6 +25524,8 @@
     },
     "node_modules/npm/node_modules/fast-json-stable-stringify": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25167,6 +25533,8 @@
     },
     "node_modules/npm/node_modules/figgy-pudding": {
       "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25174,6 +25542,8 @@
     },
     "node_modules/npm/node_modules/find-npm-prefix": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
+      "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25181,6 +25551,8 @@
     },
     "node_modules/npm/node_modules/flush-write-stream": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+      "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25192,6 +25564,8 @@
     },
     "node_modules/npm/node_modules/flush-write-stream/node_modules/readable-stream": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25208,6 +25582,8 @@
     },
     "node_modules/npm/node_modules/flush-write-stream/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25218,6 +25594,8 @@
     },
     "node_modules/npm/node_modules/forever-agent": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -25228,6 +25606,8 @@
     },
     "node_modules/npm/node_modules/form-data": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25243,6 +25623,8 @@
     },
     "node_modules/npm/node_modules/from2": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25254,6 +25636,8 @@
     },
     "node_modules/npm/node_modules/from2/node_modules/readable-stream": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25270,6 +25654,8 @@
     },
     "node_modules/npm/node_modules/from2/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25280,6 +25666,8 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25290,6 +25678,8 @@
     },
     "node_modules/npm/node_modules/fs-minipass/node_modules/minipass": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25301,6 +25691,8 @@
     },
     "node_modules/npm/node_modules/fs-vacuum": {
       "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+      "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25313,6 +25705,8 @@
     },
     "node_modules/npm/node_modules/fs-write-stream-atomic": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25326,6 +25720,8 @@
     },
     "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/iferr": {
       "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25333,6 +25729,8 @@
     },
     "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/readable-stream": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25349,6 +25747,8 @@
     },
     "node_modules/npm/node_modules/fs-write-stream-atomic/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25359,6 +25759,8 @@
     },
     "node_modules/npm/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25366,6 +25768,8 @@
     },
     "node_modules/npm/node_modules/function-bind": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25373,6 +25777,8 @@
     },
     "node_modules/npm/node_modules/gauge": {
       "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25390,6 +25796,8 @@
     },
     "node_modules/npm/node_modules/gauge/node_modules/aproba": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25397,6 +25805,8 @@
     },
     "node_modules/npm/node_modules/gauge/node_modules/string-width": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25412,6 +25822,8 @@
     },
     "node_modules/npm/node_modules/genfun": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
+      "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25419,6 +25831,8 @@
     },
     "node_modules/npm/node_modules/gentle-fs": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.3.1.tgz",
+      "integrity": "sha512-OlwBBwqCFPcjm33rF2BjW+Pr6/ll2741l+xooiwTCeaX2CA1ZuclavyMBe0/KlR21/XGsgY6hzEQZ15BdNa13Q==",
       "dev": true,
       "inBundle": true,
       "license": "Artistic-2.0",
@@ -25439,6 +25853,8 @@
     },
     "node_modules/npm/node_modules/gentle-fs/node_modules/aproba": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25446,6 +25862,8 @@
     },
     "node_modules/npm/node_modules/gentle-fs/node_modules/iferr": {
       "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25453,6 +25871,8 @@
     },
     "node_modules/npm/node_modules/get-caller-file": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25463,6 +25883,8 @@
     },
     "node_modules/npm/node_modules/get-stream": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25476,6 +25898,8 @@
     },
     "node_modules/npm/node_modules/getpass": {
       "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25486,6 +25910,8 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25507,6 +25933,8 @@
     },
     "node_modules/npm/node_modules/global-dirs": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25520,6 +25948,8 @@
     },
     "node_modules/npm/node_modules/got": {
       "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25543,6 +25973,8 @@
     },
     "node_modules/npm/node_modules/got/node_modules/get-stream": {
       "version": "3.0.0",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25553,6 +25985,8 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25560,6 +25994,8 @@
     },
     "node_modules/npm/node_modules/har-schema": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25570,6 +26006,8 @@
     },
     "node_modules/npm/node_modules/har-validator": {
       "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "deprecated": "this library is no longer supported",
       "dev": true,
       "inBundle": true,
@@ -25585,6 +26023,8 @@
     },
     "node_modules/npm/node_modules/har-validator/node_modules/ajv": {
       "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25602,6 +26042,8 @@
     },
     "node_modules/npm/node_modules/har-validator/node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25609,6 +26051,8 @@
     },
     "node_modules/npm/node_modules/har-validator/node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25616,6 +26060,8 @@
     },
     "node_modules/npm/node_modules/has": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25629,6 +26075,8 @@
     },
     "node_modules/npm/node_modules/has-flag": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25639,6 +26087,8 @@
     },
     "node_modules/npm/node_modules/has-symbols": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25649,6 +26099,8 @@
     },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25656,6 +26108,8 @@
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25663,6 +26117,8 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -25670,6 +26126,8 @@
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25684,6 +26142,8 @@
     },
     "node_modules/npm/node_modules/http-signature": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25700,6 +26160,8 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25714,6 +26176,8 @@
     },
     "node_modules/npm/node_modules/humanize-ms": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25724,6 +26188,8 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25737,6 +26203,8 @@
     },
     "node_modules/npm/node_modules/iferr": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
+      "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25747,6 +26215,8 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25757,6 +26227,8 @@
     },
     "node_modules/npm/node_modules/import-lazy": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25767,6 +26239,8 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25777,6 +26251,8 @@
     },
     "node_modules/npm/node_modules/infer-owner": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25784,6 +26260,8 @@
     },
     "node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25795,6 +26273,8 @@
     },
     "node_modules/npm/node_modules/inherits": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25802,6 +26282,8 @@
     },
     "node_modules/npm/node_modules/ini": {
       "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25809,6 +26291,8 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
+      "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -25826,6 +26310,8 @@
     },
     "node_modules/npm/node_modules/ip": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25833,6 +26319,8 @@
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25843,6 +26331,8 @@
     },
     "node_modules/npm/node_modules/is-callable": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25853,6 +26343,8 @@
     },
     "node_modules/npm/node_modules/is-ci": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25866,6 +26358,8 @@
     },
     "node_modules/npm/node_modules/is-ci/node_modules/ci-info": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25873,6 +26367,8 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-3.0.0.tgz",
+      "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -25886,6 +26382,8 @@
     },
     "node_modules/npm/node_modules/is-date-object": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25896,6 +26394,8 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25909,6 +26409,8 @@
     },
     "node_modules/npm/node_modules/is-installed-globally": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25923,6 +26425,8 @@
     },
     "node_modules/npm/node_modules/is-npm": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25933,6 +26437,8 @@
     },
     "node_modules/npm/node_modules/is-obj": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25943,6 +26449,8 @@
     },
     "node_modules/npm/node_modules/is-path-inside": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25956,6 +26464,8 @@
     },
     "node_modules/npm/node_modules/is-redirect": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25966,6 +26476,8 @@
     },
     "node_modules/npm/node_modules/is-regex": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25979,6 +26491,8 @@
     },
     "node_modules/npm/node_modules/is-retry-allowed": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25989,6 +26503,8 @@
     },
     "node_modules/npm/node_modules/is-stream": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -25999,6 +26515,8 @@
     },
     "node_modules/npm/node_modules/is-symbol": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26012,6 +26530,8 @@
     },
     "node_modules/npm/node_modules/is-typedarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26019,6 +26539,8 @@
     },
     "node_modules/npm/node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26026,6 +26548,8 @@
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26033,6 +26557,8 @@
     },
     "node_modules/npm/node_modules/isstream": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26040,6 +26566,8 @@
     },
     "node_modules/npm/node_modules/jsbn": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26048,6 +26576,8 @@
     },
     "node_modules/npm/node_modules/json-parse-better-errors": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26055,12 +26585,16 @@
     },
     "node_modules/npm/node_modules/json-schema": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true,
       "inBundle": true,
       "peer": true
     },
     "node_modules/npm/node_modules/json-stringify-safe": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26068,6 +26602,8 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true,
       "engines": [
         "node >= 0.2.0"
@@ -26078,6 +26614,8 @@
     },
     "node_modules/npm/node_modules/JSONStream": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "dev": true,
       "inBundle": true,
       "license": "(MIT OR Apache-2.0)",
@@ -26095,6 +26633,8 @@
     },
     "node_modules/npm/node_modules/jsprim": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -26111,6 +26651,8 @@
     },
     "node_modules/npm/node_modules/latest-version": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26124,6 +26666,8 @@
     },
     "node_modules/npm/node_modules/lazy-property": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+      "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26131,6 +26675,8 @@
     },
     "node_modules/npm/node_modules/libcipm": {
       "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-4.0.8.tgz",
+      "integrity": "sha512-IN3hh2yDJQtZZ5paSV4fbvJg4aHxCCg5tcZID/dSVlTuUiWktsgaldVljJv6Z5OUlYspx6xQkbR0efNodnIrOA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26155,6 +26701,8 @@
     },
     "node_modules/npm/node_modules/libnpm": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/libnpm/-/libnpm-3.0.1.tgz",
+      "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26184,6 +26732,8 @@
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.2.tgz",
+      "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26197,6 +26747,8 @@
     },
     "node_modules/npm/node_modules/libnpmconfig": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
+      "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26209,6 +26761,8 @@
     },
     "node_modules/npm/node_modules/libnpmconfig/node_modules/find-up": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26222,6 +26776,8 @@
     },
     "node_modules/npm/node_modules/libnpmconfig/node_modules/locate-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26236,6 +26792,8 @@
     },
     "node_modules/npm/node_modules/libnpmconfig/node_modules/p-limit": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26249,6 +26807,8 @@
     },
     "node_modules/npm/node_modules/libnpmconfig/node_modules/p-locate": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26262,6 +26822,8 @@
     },
     "node_modules/npm/node_modules/libnpmconfig/node_modules/p-try": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26272,6 +26834,8 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.3.tgz",
+      "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26285,6 +26849,8 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.1.tgz",
+      "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26298,6 +26864,8 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.2.tgz",
+      "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26316,6 +26884,8 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.2.tgz",
+      "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26328,6 +26898,8 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.2.tgz",
+      "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26341,6 +26913,8 @@
     },
     "node_modules/npm/node_modules/libnpx": {
       "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.4.tgz",
+      "integrity": "sha512-BPc0D1cOjBeS8VIBKUu5F80s6njm0wbVt7CsGMrIcJ+SI7pi7V0uVPGpEMH9H5L8csOcclTxAXFE2VAsJXUhfA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26361,6 +26935,8 @@
     },
     "node_modules/npm/node_modules/lock-verify": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.1.0.tgz",
+      "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26372,6 +26948,8 @@
     },
     "node_modules/npm/node_modules/lockfile": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26382,13 +26960,16 @@
     },
     "node_modules/npm/node_modules/lodash._baseindexof": {
       "version": "3.1.0",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+      "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._baseuniq": {
       "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+      "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26400,30 +26981,35 @@
     },
     "node_modules/npm/node_modules/lodash._bindcallback": {
       "version": "3.0.1",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._cacheindexof": {
       "version": "3.0.2",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+      "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._createcache": {
       "version": "3.1.2",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash._getnative": "^3.0.0"
       }
     },
     "node_modules/npm/node_modules/lodash._createset": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+      "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26431,13 +27017,16 @@
     },
     "node_modules/npm/node_modules/lodash._getnative": {
       "version": "3.9.1",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash._root": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26445,6 +27034,8 @@
     },
     "node_modules/npm/node_modules/lodash.clonedeep": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26452,13 +27043,16 @@
     },
     "node_modules/npm/node_modules/lodash.restparam": {
       "version": "3.6.1",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "extraneous": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/lodash.union": {
       "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26466,6 +27060,8 @@
     },
     "node_modules/npm/node_modules/lodash.uniq": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26473,6 +27069,8 @@
     },
     "node_modules/npm/node_modules/lodash.without": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26480,6 +27078,8 @@
     },
     "node_modules/npm/node_modules/lowercase-keys": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26490,6 +27090,8 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26500,6 +27102,8 @@
     },
     "node_modules/npm/node_modules/make-dir": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26513,6 +27117,8 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz",
+      "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26533,6 +27139,8 @@
     },
     "node_modules/npm/node_modules/meant": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.2.tgz",
+      "integrity": "sha512-KN+1uowN/NK+sT/Lzx7WSGIj2u+3xe5n2LbwObfjOhPZiA+cCfCm6idVl0RkEfjThkw5XJ96CyRcanq6GmKtUg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26540,6 +27148,8 @@
     },
     "node_modules/npm/node_modules/mime-db": {
       "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26550,6 +27160,8 @@
     },
     "node_modules/npm/node_modules/mime-types": {
       "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26563,6 +27175,8 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26576,6 +27190,8 @@
     },
     "node_modules/npm/node_modules/minimist": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26583,6 +27199,8 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26593,6 +27211,8 @@
     },
     "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26604,6 +27224,8 @@
     },
     "node_modules/npm/node_modules/mississippi": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -26626,6 +27248,8 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26639,6 +27263,8 @@
     },
     "node_modules/npm/node_modules/mkdirp/node_modules/minimist": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26646,6 +27272,8 @@
     },
     "node_modules/npm/node_modules/move-concurrently": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26661,6 +27289,8 @@
     },
     "node_modules/npm/node_modules/move-concurrently/node_modules/aproba": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26668,6 +27298,8 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26675,6 +27307,8 @@
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26682,6 +27316,8 @@
     },
     "node_modules/npm/node_modules/node-fetch-npm": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+      "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26697,6 +27333,8 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.0.tgz",
+      "integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26723,6 +27361,8 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26737,6 +27377,8 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -26750,6 +27392,8 @@
     },
     "node_modules/npm/node_modules/normalize-package-data/node_modules/resolve": {
       "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26760,6 +27404,8 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.3.tgz",
+      "integrity": "sha512-8nH/JjsFfAWMvn474HB9mpmMjrnKb1Hx/oTAdjv4PT9iZBvBxiZ+wtDUapHCJwLqYGQVPaAfs+vL5+5k9QndXw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26771,6 +27417,8 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26781,6 +27429,8 @@
     },
     "node_modules/npm/node_modules/npm-cache-filename": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+      "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26788,6 +27438,8 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.2.tgz",
+      "integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -26798,6 +27450,8 @@
     },
     "node_modules/npm/node_modules/npm-lifecycle": {
       "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
+      "integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
       "dev": true,
       "inBundle": true,
       "license": "Artistic-2.0",
@@ -26815,6 +27469,8 @@
     },
     "node_modules/npm/node_modules/npm-logical-tree": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
+      "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26822,6 +27478,8 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26829,6 +27487,8 @@
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
+      "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26842,6 +27502,8 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26854,6 +27516,8 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz",
+      "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26866,6 +27530,8 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.4.tgz",
+      "integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26878,6 +27544,8 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.7.tgz",
+      "integrity": "sha512-cny9v0+Mq6Tjz+e0erFAB+RYJ/AVGzkjnISiobqP8OWj9c9FLoZZu8/SPSKJWE17F1tk4018wfjV+ZbIbqC7fQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26894,6 +27562,8 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
       "funding": [
         {
@@ -26915,6 +27585,8 @@
     },
     "node_modules/npm/node_modules/npm-run-path": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26928,6 +27600,8 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.1.tgz",
+      "integrity": "sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -26935,6 +27609,8 @@
     },
     "node_modules/npm/node_modules/npmlog": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -26948,6 +27624,8 @@
     },
     "node_modules/npm/node_modules/number-is-nan": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26958,6 +27636,8 @@
     },
     "node_modules/npm/node_modules/oauth-sign": {
       "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -26968,6 +27648,8 @@
     },
     "node_modules/npm/node_modules/object-assign": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26978,6 +27660,8 @@
     },
     "node_modules/npm/node_modules/object-keys": {
       "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -26988,6 +27672,8 @@
     },
     "node_modules/npm/node_modules/object.getownpropertydescriptors": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27002,6 +27688,8 @@
     },
     "node_modules/npm/node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27012,6 +27700,8 @@
     },
     "node_modules/npm/node_modules/opener": {
       "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)",
@@ -27022,6 +27712,8 @@
     },
     "node_modules/npm/node_modules/os-homedir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27032,6 +27724,8 @@
     },
     "node_modules/npm/node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27042,6 +27736,8 @@
     },
     "node_modules/npm/node_modules/osenv": {
       "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27053,6 +27749,8 @@
     },
     "node_modules/npm/node_modules/p-finally": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27063,6 +27761,8 @@
     },
     "node_modules/npm/node_modules/package-json": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27079,6 +27779,8 @@
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "9.5.12",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.12.tgz",
+      "integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27118,6 +27820,8 @@
     },
     "node_modules/npm/node_modules/pacote/node_modules/minipass": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27129,6 +27833,8 @@
     },
     "node_modules/npm/node_modules/parallel-transform": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27141,6 +27847,8 @@
     },
     "node_modules/npm/node_modules/parallel-transform/node_modules/readable-stream": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27157,6 +27865,8 @@
     },
     "node_modules/npm/node_modules/parallel-transform/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27167,6 +27877,8 @@
     },
     "node_modules/npm/node_modules/path-exists": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27177,6 +27889,8 @@
     },
     "node_modules/npm/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27187,6 +27901,8 @@
     },
     "node_modules/npm/node_modules/path-is-inside": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)",
@@ -27194,6 +27910,8 @@
     },
     "node_modules/npm/node_modules/path-key": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27204,6 +27922,8 @@
     },
     "node_modules/npm/node_modules/path-parse": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27211,6 +27931,8 @@
     },
     "node_modules/npm/node_modules/performance-now": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27218,6 +27940,8 @@
     },
     "node_modules/npm/node_modules/pify": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27228,6 +27952,8 @@
     },
     "node_modules/npm/node_modules/prepend-http": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27238,6 +27964,8 @@
     },
     "node_modules/npm/node_modules/process-nextick-args": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27245,6 +27973,8 @@
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27252,6 +27982,8 @@
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27266,6 +27998,8 @@
     },
     "node_modules/npm/node_modules/promise-retry/node_modules/retry": {
       "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27276,6 +28010,8 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+      "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27286,6 +28022,8 @@
     },
     "node_modules/npm/node_modules/proto-list": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27293,6 +28031,8 @@
     },
     "node_modules/npm/node_modules/protoduck": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
+      "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27303,6 +28043,8 @@
     },
     "node_modules/npm/node_modules/prr": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27310,6 +28052,8 @@
     },
     "node_modules/npm/node_modules/pseudomap": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27317,6 +28061,8 @@
     },
     "node_modules/npm/node_modules/psl": {
       "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27324,6 +28070,8 @@
     },
     "node_modules/npm/node_modules/pump": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27335,6 +28083,8 @@
     },
     "node_modules/npm/node_modules/pumpify": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27347,6 +28097,8 @@
     },
     "node_modules/npm/node_modules/pumpify/node_modules/pump": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27358,6 +28110,8 @@
     },
     "node_modules/npm/node_modules/punycode": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27365,6 +28119,8 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
       "dev": true,
       "inBundle": true,
       "peer": true,
@@ -27374,6 +28130,8 @@
     },
     "node_modules/npm/node_modules/qs": {
       "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -27384,6 +28142,8 @@
     },
     "node_modules/npm/node_modules/query-string": {
       "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
+      "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27399,6 +28159,8 @@
     },
     "node_modules/npm/node_modules/qw": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
+      "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27406,6 +28168,8 @@
     },
     "node_modules/npm/node_modules/rc": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
@@ -27422,6 +28186,8 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27435,6 +28201,8 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz",
+      "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27445,12 +28213,15 @@
     },
     "node_modules/npm/node_modules/read-installed": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+      "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
       "dependencies": {
         "debuglog": "^1.0.1",
+        "graceful-fs": "^4.1.2",
         "read-package-json": "^2.0.0",
         "readdir-scoped-modules": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
@@ -27463,12 +28234,15 @@
     },
     "node_modules/npm/node_modules/read-package-json": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
+      "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
       "dependencies": {
         "glob": "^7.1.1",
+        "graceful-fs": "^4.1.2",
         "json-parse-better-errors": "^1.0.1",
         "normalize-package-data": "^2.0.0",
         "npm-normalize-package-bin": "^1.0.0"
@@ -27479,6 +28253,8 @@
     },
     "node_modules/npm/node_modules/read-package-tree": {
       "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
+      "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27491,6 +28267,8 @@
     },
     "node_modules/npm/node_modules/readable-stream": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27506,6 +28284,8 @@
     },
     "node_modules/npm/node_modules/readdir-scoped-modules": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27519,6 +28299,8 @@
     },
     "node_modules/npm/node_modules/registry-auth-token": {
       "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27530,6 +28312,8 @@
     },
     "node_modules/npm/node_modules/registry-url": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27543,6 +28327,8 @@
     },
     "node_modules/npm/node_modules/request": {
       "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -27575,6 +28361,8 @@
     },
     "node_modules/npm/node_modules/require-directory": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27585,6 +28373,8 @@
     },
     "node_modules/npm/node_modules/require-main-filename": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27592,6 +28382,8 @@
     },
     "node_modules/npm/node_modules/resolve-from": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27602,6 +28394,8 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27612,6 +28406,8 @@
     },
     "node_modules/npm/node_modules/rimraf": {
       "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27625,6 +28421,8 @@
     },
     "node_modules/npm/node_modules/run-queue": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27635,6 +28433,8 @@
     },
     "node_modules/npm/node_modules/run-queue/node_modules/aproba": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27642,6 +28442,8 @@
     },
     "node_modules/npm/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27649,6 +28451,8 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27656,6 +28460,8 @@
     },
     "node_modules/npm/node_modules/semver": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27666,6 +28472,8 @@
     },
     "node_modules/npm/node_modules/semver-diff": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27679,6 +28487,8 @@
     },
     "node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27686,6 +28496,8 @@
     },
     "node_modules/npm/node_modules/sha": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sha/-/sha-3.0.0.tgz",
+      "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
       "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT)",
@@ -27696,6 +28508,8 @@
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27709,6 +28523,8 @@
     },
     "node_modules/npm/node_modules/shebang-regex": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27719,6 +28535,8 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27726,6 +28544,8 @@
     },
     "node_modules/npm/node_modules/slide": {
       "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27736,6 +28556,8 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27747,6 +28569,8 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
+      "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27762,6 +28586,8 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27776,6 +28602,8 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent/node_modules/agent-base": {
       "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27789,6 +28617,8 @@
     },
     "node_modules/npm/node_modules/sorted-object": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+      "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
       "dev": true,
       "inBundle": true,
       "license": "(WTFPL OR MIT)",
@@ -27796,6 +28626,8 @@
     },
     "node_modules/npm/node_modules/sorted-union-stream": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+      "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27807,6 +28639,8 @@
     },
     "node_modules/npm/node_modules/sorted-union-stream/node_modules/from2": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+      "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27818,6 +28652,8 @@
     },
     "node_modules/npm/node_modules/sorted-union-stream/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27825,6 +28661,8 @@
     },
     "node_modules/npm/node_modules/sorted-union-stream/node_modules/readable-stream": {
       "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27838,6 +28676,8 @@
     },
     "node_modules/npm/node_modules/sorted-union-stream/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27845,6 +28685,8 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -27856,6 +28698,8 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0",
@@ -27863,6 +28707,8 @@
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27874,6 +28720,8 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0",
@@ -27881,6 +28729,8 @@
     },
     "node_modules/npm/node_modules/split-on-first": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27891,6 +28741,8 @@
     },
     "node_modules/npm/node_modules/sshpk": {
       "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27898,9 +28750,13 @@
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
         "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
         "getpass": "^0.1.1",
-        "safer-buffer": "^2.0.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       },
       "bin": {
         "sshpk-conv": "bin/sshpk-conv",
@@ -27919,6 +28775,8 @@
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -27929,6 +28787,8 @@
     },
     "node_modules/npm/node_modules/stream-each": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27940,6 +28800,8 @@
     },
     "node_modules/npm/node_modules/stream-iterate": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+      "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27951,6 +28813,8 @@
     },
     "node_modules/npm/node_modules/stream-iterate/node_modules/readable-stream": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27967,6 +28831,8 @@
     },
     "node_modules/npm/node_modules/stream-iterate/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27977,6 +28843,8 @@
     },
     "node_modules/npm/node_modules/stream-shift": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27984,6 +28852,8 @@
     },
     "node_modules/npm/node_modules/strict-uri-encode": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -27994,6 +28864,8 @@
     },
     "node_modules/npm/node_modules/string_decoder": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28004,6 +28876,8 @@
     },
     "node_modules/npm/node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28011,6 +28885,8 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28025,6 +28901,8 @@
     },
     "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28035,6 +28913,8 @@
     },
     "node_modules/npm/node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28045,6 +28925,8 @@
     },
     "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28058,6 +28940,8 @@
     },
     "node_modules/npm/node_modules/stringify-package": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
+      "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28065,6 +28949,8 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28078,6 +28964,8 @@
     },
     "node_modules/npm/node_modules/strip-eof": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28088,6 +28976,8 @@
     },
     "node_modules/npm/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28098,6 +28988,8 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28111,6 +29003,8 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28130,6 +29024,8 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minipass": {
       "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28141,6 +29037,8 @@
     },
     "node_modules/npm/node_modules/term-size": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28154,6 +29052,8 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28161,6 +29061,8 @@
     },
     "node_modules/npm/node_modules/through": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28168,6 +29070,8 @@
     },
     "node_modules/npm/node_modules/through2": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28179,6 +29083,8 @@
     },
     "node_modules/npm/node_modules/through2/node_modules/readable-stream": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28195,6 +29101,8 @@
     },
     "node_modules/npm/node_modules/through2/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28205,6 +29113,8 @@
     },
     "node_modules/npm/node_modules/timed-out": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28215,6 +29125,8 @@
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
+      "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28222,6 +29134,8 @@
     },
     "node_modules/npm/node_modules/tough-cookie": {
       "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -28236,6 +29150,8 @@
     },
     "node_modules/npm/node_modules/tunnel-agent": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -28249,6 +29165,8 @@
     },
     "node_modules/npm/node_modules/tweetnacl": {
       "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "inBundle": true,
       "license": "Unlicense",
@@ -28257,6 +29175,8 @@
     },
     "node_modules/npm/node_modules/typedarray": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28264,6 +29184,8 @@
     },
     "node_modules/npm/node_modules/uid-number": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28274,6 +29196,8 @@
     },
     "node_modules/npm/node_modules/umask": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+      "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28281,6 +29205,8 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28291,6 +29217,8 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28301,6 +29229,8 @@
     },
     "node_modules/npm/node_modules/unique-string": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28314,6 +29244,8 @@
     },
     "node_modules/npm/node_modules/unpipe": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28324,6 +29256,8 @@
     },
     "node_modules/npm/node_modules/unzip-response": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28334,6 +29268,8 @@
     },
     "node_modules/npm/node_modules/update-notifier": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -28356,6 +29292,8 @@
     },
     "node_modules/npm/node_modules/uri-js": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -28366,6 +29304,8 @@
     },
     "node_modules/npm/node_modules/uri-js/node_modules/punycode": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28376,6 +29316,8 @@
     },
     "node_modules/npm/node_modules/url-parse-lax": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28389,6 +29331,8 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28396,6 +29340,8 @@
     },
     "node_modules/npm/node_modules/util-extend": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28403,6 +29349,8 @@
     },
     "node_modules/npm/node_modules/util-promisify": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
+      "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28413,6 +29361,8 @@
     },
     "node_modules/npm/node_modules/uuid": {
       "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28423,6 +29373,8 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -28434,6 +29386,8 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28444,6 +29398,8 @@
     },
     "node_modules/npm/node_modules/verror": {
       "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -28459,6 +29415,8 @@
     },
     "node_modules/npm/node_modules/wcwidth": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28469,6 +29427,8 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28482,6 +29442,8 @@
     },
     "node_modules/npm/node_modules/which-module": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28489,6 +29451,8 @@
     },
     "node_modules/npm/node_modules/wide-align": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28499,6 +29463,8 @@
     },
     "node_modules/npm/node_modules/wide-align/node_modules/string-width": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28514,6 +29480,8 @@
     },
     "node_modules/npm/node_modules/widest-line": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28527,6 +29495,8 @@
     },
     "node_modules/npm/node_modules/worker-farm": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28537,6 +29507,8 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28552,6 +29524,8 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28562,6 +29536,8 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28572,6 +29548,8 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28587,6 +29565,8 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28600,6 +29580,8 @@
     },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28607,6 +29589,8 @@
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28619,6 +29603,8 @@
     },
     "node_modules/npm/node_modules/xdg-basedir": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28629,6 +29615,8 @@
     },
     "node_modules/npm/node_modules/xtend": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28639,6 +29627,8 @@
     },
     "node_modules/npm/node_modules/y18n": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28646,6 +29636,8 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28653,6 +29645,8 @@
     },
     "node_modules/npm/node_modules/yargs": {
       "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+      "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28673,6 +29667,8 @@
     },
     "node_modules/npm/node_modules/yargs-parser": {
       "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+      "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -28684,6 +29680,8 @@
     },
     "node_modules/npm/node_modules/yargs-parser/node_modules/camelcase": {
       "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28694,6 +29692,8 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/ansi-regex": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28704,6 +29704,8 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/find-up": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28717,6 +29719,8 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28727,6 +29731,8 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/locate-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28741,6 +29747,8 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/p-limit": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28757,6 +29765,8 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/p-locate": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28770,6 +29780,8 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/p-try": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28780,6 +29792,8 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/string-width": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -28795,6 +29809,8 @@
     },
     "node_modules/npm/node_modules/yargs/node_modules/strip-ansi": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -35003,8 +36019,10 @@
       "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
       "dev": true,
       "dependencies": {
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -36707,24 +37725,6 @@
             "escalade": "^3.1.0",
             "node-releases": "^1.1.61"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001148",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
-          "integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.581",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.581.tgz",
-          "integrity": "sha512-ALORbI23YkYJoVJWusSdmTq8vXH3TLFzniILE47uZkZOim135ZhoTCM7QlIuvmK78As5kLdANfy7kDIQvJ+iPw==",
-          "dev": true
-        },
-        "node-releases": {
-          "version": "1.1.63",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.63.tgz",
-          "integrity": "sha512-ukW3iCfQaoxJkSPN+iK7KznTeqDGVJatAEuXsJERYHa9tn/KaT5lBdIyxQjLEVTzSkyjJEuQ17/vaEjrOauDkg==",
-          "dev": true
         }
       }
     },
@@ -44905,6 +45905,31 @@
         "node-releases": "^1.1.29"
       }
     },
+    "browserslist-browserstack": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/browserslist-browserstack/-/browserslist-browserstack-3.1.1.tgz",
+      "integrity": "sha512-iKFpdr6tQvZJn1tAF/cCqWIcm7xDpiP17hFuntMKRfWCzLO2WC+tNwM5pWgHY4ktvwvL9OaDI9rjVcuQ3YDpHg==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.14.7",
+        "node-fetch": "^2.3.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.16.8",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.8.tgz",
+          "integrity": "sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001251",
+            "colorette": "^1.3.0",
+            "electron-to-chromium": "^1.3.811",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.75"
+          }
+        }
+      }
+    },
     "browserstack": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/browserstack/-/browserstack-1.5.3.tgz",
@@ -45108,9 +46133,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000989",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-      "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
+      "version": "1.0.30001251",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
       "dev": true
     },
     "capture-exit": {
@@ -45443,9 +46468,9 @@
       "dev": true
     },
     "colorette": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
+      "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
       "dev": true
     },
     "colors": {
@@ -46137,24 +47162,6 @@
             "escalade": "^3.1.0",
             "node-releases": "^1.1.61"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001148",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
-          "integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.581",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.581.tgz",
-          "integrity": "sha512-ALORbI23YkYJoVJWusSdmTq8vXH3TLFzniILE47uZkZOim135ZhoTCM7QlIuvmK78As5kLdANfy7kDIQvJ+iPw==",
-          "dev": true
-        },
-        "node-releases": {
-          "version": "1.1.63",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.63.tgz",
-          "integrity": "sha512-ukW3iCfQaoxJkSPN+iK7KznTeqDGVJatAEuXsJERYHa9tn/KaT5lBdIyxQjLEVTzSkyjJEuQ17/vaEjrOauDkg==",
-          "dev": true
         },
         "semver": {
           "version": "7.0.0",
@@ -46890,9 +47897,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.247",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.247.tgz",
-      "integrity": "sha512-j/Rzx1FyVTwNifpG/DPQKEMz0mruRwoPpJ6Y1tTVmj6+/zAVzG8/YHZwBMLYCZgQH6seLOqaVxZ3RY3KMrT5IQ==",
+      "version": "1.3.814",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.814.tgz",
+      "integrity": "sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw==",
       "dev": true
     },
     "elliptic": {
@@ -48373,24 +49380,32 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48401,12 +49416,16 @@
         },
         "balanced-match": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48417,36 +49436,48 @@
         },
         "chownr": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48456,24 +49487,32 @@
         },
         "deep-extend": {
           "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48483,12 +49522,16 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48505,6 +49548,8 @@
         },
         "glob": {
           "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48519,12 +49564,16 @@
         },
         "has-unicode": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48534,6 +49583,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48543,6 +49594,8 @@
         },
         "inflight": {
           "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48553,18 +49606,24 @@
         },
         "inherits": {
           "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48574,12 +49633,16 @@
         },
         "isarray": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48589,12 +49652,16 @@
         },
         "minimist": {
           "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48605,6 +49672,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48614,6 +49683,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48623,12 +49694,16 @@
         },
         "ms": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48640,6 +49715,8 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+          "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48658,6 +49735,8 @@
         },
         "nopt": {
           "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48668,12 +49747,16 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48684,6 +49767,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48696,18 +49781,24 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48717,18 +49808,24 @@
         },
         "os-homedir": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48739,18 +49836,24 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48763,6 +49866,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -48771,6 +49876,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48786,6 +49893,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48795,42 +49904,56 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48840,6 +49963,8 @@
         },
         "string-width": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48851,6 +49976,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48860,12 +49987,16 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48881,12 +50012,16 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -48896,12 +50031,16 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -55854,13 +56993,10 @@
       }
     },
     "node-releases": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.29.tgz",
-      "integrity": "sha512-R5bDhzh6I+tpi/9i2hrrvGJ3yKPYzlVOORDkXhnZuwi5D3q1I5w4vYy24PJXTcLk9Q0kws9TO77T75bcK8/ysQ==",
-      "dev": true,
-      "requires": {
-        "semver": "^5.3.0"
-      }
+      "version": "1.1.75",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
+      "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -56024,12 +57160,16 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "agent-base": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56039,6 +57179,8 @@
         },
         "agentkeepalive": {
           "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-3.5.2.tgz",
+          "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56048,6 +57190,8 @@
         },
         "ansi-align": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56057,12 +57201,16 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "ansi-styles": {
           "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56072,30 +57220,40 @@
         },
         "ansicolors": {
           "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "ansistyles": {
           "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
+          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "aproba": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "archy": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56106,6 +57264,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -56121,6 +57281,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -56132,12 +57294,16 @@
         },
         "asap": {
           "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "asn1": {
           "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56147,36 +57313,48 @@
         },
         "assert-plus": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "asynckit": {
           "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "aws-sign2": {
           "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "aws4": {
           "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "balanced-match": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -56187,6 +57365,8 @@
         },
         "bin-links": {
           "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.8.tgz",
+          "integrity": "sha512-KgmVfx+QqggqP9dA3iIc5pA4T1qEEEL+hOhOhNPaUm77OTrJoOXE/C05SJLNJe6m/2wUK7F1tDSou7n5TfCDzQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56201,12 +57381,16 @@
         },
         "bluebird": {
           "version": "3.5.5",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "boxen": {
           "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56222,6 +57406,8 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56232,30 +57418,40 @@
         },
         "buffer-from": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+          "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "builtins": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "byline": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+          "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "byte-size": {
           "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz",
+          "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "cacache": {
           "version": "12.0.3",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+          "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56279,30 +57475,40 @@
         },
         "call-limit": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/call-limit/-/call-limit-1.1.1.tgz",
+          "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "camelcase": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+          "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "caseless": {
           "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "chalk": {
           "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56314,18 +57520,24 @@
         },
         "chownr": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "ci-info": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "cidr-regex": {
           "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-2.0.10.tgz",
+          "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56335,12 +57547,16 @@
         },
         "cli-boxes": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "cli-columns": {
           "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/cli-columns/-/cli-columns-3.1.2.tgz",
+          "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56351,6 +57567,8 @@
         },
         "cli-table3": {
           "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+          "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56362,6 +57580,8 @@
         },
         "cliui": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56373,18 +57593,24 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "string-width": {
               "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -56396,6 +57622,8 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -56407,12 +57635,16 @@
         },
         "clone": {
           "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "cmd-shim": {
           "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-3.0.3.tgz",
+          "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56423,12 +57655,16 @@
         },
         "code-point-at": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "color-convert": {
           "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56438,12 +57674,16 @@
         },
         "color-name": {
           "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "colors": {
           "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+          "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -56451,6 +57691,8 @@
         },
         "columnify": {
           "version": "1.5.4",
+          "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56461,6 +57703,8 @@
         },
         "combined-stream": {
           "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56470,12 +57714,16 @@
         },
         "concat-map": {
           "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "concat-stream": {
           "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56488,6 +57736,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -56503,6 +57753,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -56514,6 +57766,8 @@
         },
         "config-chain": {
           "version": "1.1.12",
+          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+          "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56524,6 +57778,8 @@
         },
         "configstore": {
           "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.5.tgz",
+          "integrity": "sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56538,12 +57794,16 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+          "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56558,12 +57818,16 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "iferr": {
               "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -56572,12 +57836,16 @@
         },
         "core-util-is": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "create-error-class": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56587,6 +57855,8 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56598,6 +57868,8 @@
           "dependencies": {
             "lru-cache": {
               "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+              "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -56608,6 +57880,8 @@
             },
             "yallist": {
               "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -56616,18 +57890,24 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "cyclist": {
           "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+          "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "dashdash": {
           "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56637,6 +57917,8 @@
         },
         "debug": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56646,6 +57928,8 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -56654,30 +57938,40 @@
         },
         "debuglog": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "decamelize": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "deep-extend": {
           "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "defaults": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+          "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56687,6 +57981,8 @@
         },
         "define-properties": {
           "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56696,30 +57992,40 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "delegates": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "detect-indent": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "detect-newline": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "dezalgo": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56730,6 +58036,8 @@
         },
         "dot-prop": {
           "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56739,18 +58047,24 @@
         },
         "dotenv": {
           "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "duplexer3": {
           "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "duplexify": {
           "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+          "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56763,6 +58077,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -56778,6 +58094,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -56789,6 +58107,8 @@
         },
         "ecc-jsbn": {
           "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -56800,18 +58120,24 @@
         },
         "editor": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
+          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "emoji-regex": {
           "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "encoding": {
           "version": "0.1.12",
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56821,6 +58147,8 @@
         },
         "end-of-stream": {
           "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56830,18 +58158,24 @@
         },
         "env-paths": {
           "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+          "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "err-code": {
           "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "errno": {
           "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+          "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56851,6 +58185,8 @@
         },
         "es-abstract": {
           "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+          "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56864,6 +58200,8 @@
         },
         "es-to-primitive": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+          "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56875,12 +58213,16 @@
         },
         "es6-promise": {
           "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "es6-promisify": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56890,12 +58232,16 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "execa": {
           "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56911,6 +58257,8 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
+              "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -56919,36 +58267,48 @@
         },
         "extend": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "extsprintf": {
           "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "figgy-pudding": {
           "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+          "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
+          "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "flush-write-stream": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+          "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -56959,6 +58319,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -56974,6 +58336,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -56985,12 +58349,16 @@
         },
         "forever-agent": {
           "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "form-data": {
           "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57002,6 +58370,8 @@
         },
         "from2": {
           "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+          "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57012,6 +58382,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -57027,6 +58399,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -57038,6 +58412,8 @@
         },
         "fs-minipass": {
           "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57047,6 +58423,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -57059,6 +58437,8 @@
         },
         "fs-vacuum": {
           "version": "1.2.10",
+          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+          "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57070,6 +58450,8 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57082,12 +58464,16 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "readable-stream": {
               "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -57103,6 +58489,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -57114,18 +58502,24 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "function-bind": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "gauge": {
           "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57142,12 +58536,16 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "string-width": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -57161,12 +58559,16 @@
         },
         "genfun": {
           "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
+          "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "gentle-fs": {
           "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.3.1.tgz",
+          "integrity": "sha512-OlwBBwqCFPcjm33rF2BjW+Pr6/ll2741l+xooiwTCeaX2CA1ZuclavyMBe0/KlR21/XGsgY6hzEQZ15BdNa13Q==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57186,12 +58588,16 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "iferr": {
               "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -57200,12 +58606,16 @@
         },
         "get-caller-file": {
           "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "get-stream": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57215,6 +58625,8 @@
         },
         "getpass": {
           "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57224,6 +58636,8 @@
         },
         "glob": {
           "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57238,6 +58652,8 @@
         },
         "global-dirs": {
           "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57247,6 +58663,8 @@
         },
         "got": {
           "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57266,6 +58684,8 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
+              "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -57274,18 +58694,24 @@
         },
         "graceful-fs": {
           "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "har-schema": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "har-validator": {
           "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57296,6 +58722,8 @@
           "dependencies": {
             "ajv": {
               "version": "6.12.6",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+              "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -57308,12 +58736,16 @@
             },
             "fast-deep-equal": {
               "version": "3.1.3",
+              "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+              "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "json-schema-traverse": {
               "version": "0.4.1",
+              "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+              "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -57322,6 +58754,8 @@
         },
         "has": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57331,36 +58765,48 @@
         },
         "has-flag": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "has-symbols": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+          "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "has-unicode": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "hosted-git-info": {
           "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "http-cache-semantics": {
           "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+          "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "http-proxy-agent": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+          "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57371,6 +58817,8 @@
         },
         "http-signature": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57382,6 +58830,8 @@
         },
         "https-proxy-agent": {
           "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57392,6 +58842,8 @@
         },
         "humanize-ms": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57401,6 +58853,8 @@
         },
         "iconv-lite": {
           "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57410,12 +58864,16 @@
         },
         "iferr": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
+          "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "ignore-walk": {
           "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57425,24 +58883,32 @@
         },
         "import-lazy": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "imurmurhash": {
           "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "infer-owner": {
           "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+          "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "inflight": {
           "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57453,18 +58919,24 @@
         },
         "inherits": {
           "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "ini": {
           "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "init-package-json": {
           "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.10.3.tgz",
+          "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57481,24 +58953,32 @@
         },
         "ip": {
           "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "ip-regex": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "is-callable": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "is-ci": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57508,6 +58988,8 @@
           "dependencies": {
             "ci-info": {
               "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+              "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -57516,6 +58998,8 @@
         },
         "is-cidr": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-3.0.0.tgz",
+          "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57525,12 +59009,16 @@
         },
         "is-date-object": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+          "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57540,6 +59028,8 @@
         },
         "is-installed-globally": {
           "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57550,18 +59040,24 @@
         },
         "is-npm": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "is-obj": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "is-path-inside": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57571,12 +59067,16 @@
         },
         "is-redirect": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "is-regex": {
           "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+          "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57586,18 +59086,24 @@
         },
         "is-retry-allowed": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+          "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "is-stream": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "is-symbol": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+          "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57607,30 +59113,40 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "isarray": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "isexe": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "isstream": {
           "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "jsbn": {
           "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -57638,30 +59154,40 @@
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "json-schema": {
           "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "jsonparse": {
           "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+          "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "JSONStream": {
           "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+          "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57672,6 +59198,8 @@
         },
         "jsprim": {
           "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57684,6 +59212,8 @@
         },
         "latest-version": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57693,12 +59223,16 @@
         },
         "lazy-property": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
+          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "libcipm": {
           "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/libcipm/-/libcipm-4.0.8.tgz",
+          "integrity": "sha512-IN3hh2yDJQtZZ5paSV4fbvJg4aHxCCg5tcZID/dSVlTuUiWktsgaldVljJv6Z5OUlYspx6xQkbR0efNodnIrOA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57722,6 +59256,8 @@
         },
         "libnpm": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/libnpm/-/libnpm-3.0.1.tgz",
+          "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57750,6 +59286,8 @@
         },
         "libnpmaccess": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.2.tgz",
+          "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57762,6 +59300,8 @@
         },
         "libnpmconfig": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
+          "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57773,6 +59313,8 @@
           "dependencies": {
             "find-up": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -57782,6 +59324,8 @@
             },
             "locate-path": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -57792,6 +59336,8 @@
             },
             "p-limit": {
               "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+              "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -57801,6 +59347,8 @@
             },
             "p-locate": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -57810,6 +59358,8 @@
             },
             "p-try": {
               "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -57818,6 +59368,8 @@
         },
         "libnpmhook": {
           "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.3.tgz",
+          "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57830,6 +59382,8 @@
         },
         "libnpmorg": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.1.tgz",
+          "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57842,6 +59396,8 @@
         },
         "libnpmpublish": {
           "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.2.tgz",
+          "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57859,6 +59415,8 @@
         },
         "libnpmsearch": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.2.tgz",
+          "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57870,6 +59428,8 @@
         },
         "libnpmteam": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.2.tgz",
+          "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57882,6 +59442,8 @@
         },
         "libnpx": {
           "version": "10.2.4",
+          "resolved": "https://registry.npmjs.org/libnpx/-/libnpx-10.2.4.tgz",
+          "integrity": "sha512-BPc0D1cOjBeS8VIBKUu5F80s6njm0wbVt7CsGMrIcJ+SI7pi7V0uVPGpEMH9H5L8csOcclTxAXFE2VAsJXUhfA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57898,6 +59460,8 @@
         },
         "lock-verify": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.1.0.tgz",
+          "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57908,6 +59472,8 @@
         },
         "lockfile": {
           "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+          "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57917,12 +59483,15 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
           "bundled": true,
-          "dev": true,
-          "peer": true
+          "extraneous": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -57933,81 +59502,102 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
           "bundled": true,
-          "dev": true,
-          "peer": true
+          "extraneous": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
           "bundled": true,
-          "dev": true,
-          "peer": true
+          "extraneous": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "bundled": true,
-          "dev": true,
-          "peer": true,
+          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._createset": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+          "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
           "bundled": true,
-          "dev": true,
-          "peer": true
+          "extraneous": true
         },
         "lodash._root": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+          "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
           "bundled": true,
-          "dev": true,
-          "peer": true
+          "extraneous": true
         },
         "lodash.union": {
           "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "lodash.without": {
           "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "lowercase-keys": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "lru-cache": {
           "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58017,6 +59607,8 @@
         },
         "make-dir": {
           "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58026,6 +59618,8 @@
         },
         "make-fetch-happen": {
           "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz",
+          "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58045,18 +59639,24 @@
         },
         "meant": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.2.tgz",
+          "integrity": "sha512-KN+1uowN/NK+sT/Lzx7WSGIj2u+3xe5n2LbwObfjOhPZiA+cCfCm6idVl0RkEfjThkw5XJ96CyRcanq6GmKtUg==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "mime-db": {
           "version": "1.35.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "mime-types": {
           "version": "2.1.19",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+          "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58066,6 +59666,8 @@
         },
         "minimatch": {
           "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58075,12 +59677,16 @@
         },
         "minimist": {
           "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "minizlib": {
           "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58090,6 +59696,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -58102,6 +59710,8 @@
         },
         "mississippi": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+          "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58120,6 +59730,8 @@
         },
         "mkdirp": {
           "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58129,6 +59741,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -58137,6 +59751,8 @@
         },
         "move-concurrently": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58151,6 +59767,8 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -58159,18 +59777,24 @@
         },
         "ms": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "mute-stream": {
           "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "node-fetch-npm": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
+          "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58182,6 +59806,8 @@
         },
         "node-gyp": {
           "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.0.tgz",
+          "integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58201,6 +59827,8 @@
         },
         "nopt": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58211,6 +59839,8 @@
         },
         "normalize-package-data": {
           "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58223,6 +59853,8 @@
           "dependencies": {
             "resolve": {
               "version": "1.10.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+              "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -58234,6 +59866,8 @@
         },
         "npm-audit-report": {
           "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/npm-audit-report/-/npm-audit-report-1.3.3.tgz",
+          "integrity": "sha512-8nH/JjsFfAWMvn474HB9mpmMjrnKb1Hx/oTAdjv4PT9iZBvBxiZ+wtDUapHCJwLqYGQVPaAfs+vL5+5k9QndXw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58244,6 +59878,8 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58253,12 +59889,16 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
+          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "npm-install-checks": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.2.tgz",
+          "integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58268,6 +59908,8 @@
         },
         "npm-lifecycle": {
           "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
+          "integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58284,18 +59926,24 @@
         },
         "npm-logical-tree": {
           "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
+          "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "npm-package-arg": {
           "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
+          "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58308,6 +59956,8 @@
         },
         "npm-packlist": {
           "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+          "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58319,6 +59969,8 @@
         },
         "npm-pick-manifest": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz",
+          "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58330,6 +59982,8 @@
         },
         "npm-profile": {
           "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.4.tgz",
+          "integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58341,6 +59995,8 @@
         },
         "npm-registry-fetch": {
           "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.7.tgz",
+          "integrity": "sha512-cny9v0+Mq6Tjz+e0erFAB+RYJ/AVGzkjnISiobqP8OWj9c9FLoZZu8/SPSKJWE17F1tk4018wfjV+ZbIbqC7fQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58356,6 +60012,8 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -58364,6 +60022,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58373,12 +60033,16 @@
         },
         "npm-user-validate": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-1.0.1.tgz",
+          "integrity": "sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "npmlog": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58391,30 +60055,40 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "oauth-sign": {
           "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "object-assign": {
           "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "object-keys": {
           "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+          "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "object.getownpropertydescriptors": {
           "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+          "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58425,6 +60099,8 @@
         },
         "once": {
           "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58434,24 +60110,32 @@
         },
         "opener": {
           "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+          "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "os-homedir": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "osenv": {
           "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58462,12 +60146,16 @@
         },
         "p-finally": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "package-json": {
           "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58480,6 +60168,8 @@
         },
         "pacote": {
           "version": "9.5.12",
+          "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.12.tgz",
+          "integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58518,6 +60208,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -58530,6 +60222,8 @@
         },
         "parallel-transform": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+          "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58541,6 +60235,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -58556,6 +60252,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -58567,66 +60265,88 @@
         },
         "path-exists": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "path-is-inside": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "path-key": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "path-parse": {
           "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "performance-now": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "pify": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "prepend-http": {
           "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "promise-inflight": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "promise-retry": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+          "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58637,6 +60357,8 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -58645,6 +60367,8 @@
         },
         "promzard": {
           "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
+          "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58654,12 +60378,16 @@
         },
         "proto-list": {
           "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+          "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "protoduck": {
           "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/protoduck/-/protoduck-5.0.1.tgz",
+          "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58669,24 +60397,32 @@
         },
         "prr": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "pseudomap": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "psl": {
           "version": "1.1.29",
+          "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+          "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "pump": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58697,6 +60433,8 @@
         },
         "pumpify": {
           "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58708,6 +60446,8 @@
           "dependencies": {
             "pump": {
               "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -58720,24 +60460,32 @@
         },
         "punycode": {
           "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+          "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "qs": {
           "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "query-string": {
           "version": "6.8.2",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
+          "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58749,12 +60497,16 @@
         },
         "qw": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/qw/-/qw-1.0.1.tgz",
+          "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "rc": {
           "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58767,6 +60519,8 @@
         },
         "read": {
           "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58776,6 +60530,8 @@
         },
         "read-cmd-shim": {
           "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz",
+          "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58785,6 +60541,8 @@
         },
         "read-installed": {
           "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58800,6 +60558,8 @@
         },
         "read-package-json": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
+          "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58813,6 +60573,8 @@
         },
         "read-package-tree": {
           "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
+          "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58824,6 +60586,8 @@
         },
         "readable-stream": {
           "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58835,6 +60599,8 @@
         },
         "readdir-scoped-modules": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+          "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58847,6 +60613,8 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58857,6 +60625,8 @@
         },
         "registry-url": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58866,6 +60636,8 @@
         },
         "request": {
           "version": "2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58894,30 +60666,40 @@
         },
         "require-directory": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "require-main-filename": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "resolve-from": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "retry": {
           "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "rimraf": {
           "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58927,6 +60709,8 @@
         },
         "run-queue": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+          "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58936,6 +60720,8 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -58944,24 +60730,32 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "safer-buffer": {
           "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "semver": {
           "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "semver-diff": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58971,12 +60765,16 @@
         },
         "set-blocking": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "sha": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/sha/-/sha-3.0.0.tgz",
+          "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58986,6 +60784,8 @@
         },
         "shebang-command": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -58995,30 +60795,40 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "signal-exit": {
           "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "slide": {
           "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "smart-buffer": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+          "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "socks": {
           "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
+          "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59029,6 +60839,8 @@
         },
         "socks-proxy-agent": {
           "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+          "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59039,6 +60851,8 @@
           "dependencies": {
             "agent-base": {
               "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+              "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59050,12 +60864,16 @@
         },
         "sorted-object": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
+          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
+          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59066,6 +60884,8 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
+              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59076,12 +60896,16 @@
             },
             "isarray": {
               "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "readable-stream": {
               "version": "1.1.14",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59094,6 +60918,8 @@
             },
             "string_decoder": {
               "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -59102,6 +60928,8 @@
         },
         "spdx-correct": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59112,12 +60940,16 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59128,18 +60960,24 @@
         },
         "spdx-license-ids": {
           "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+          "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "split-on-first": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+          "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "sshpk": {
           "version": "1.14.2",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+          "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59157,6 +60995,8 @@
         },
         "ssri": {
           "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59166,6 +61006,8 @@
         },
         "stream-each": {
           "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+          "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59176,6 +61018,8 @@
         },
         "stream-iterate": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
+          "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59186,6 +61030,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59201,6 +61047,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59212,18 +61060,24 @@
         },
         "stream-shift": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "strict-uri-encode": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "string_decoder": {
           "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59233,6 +61087,8 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+              "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -59241,6 +61097,8 @@
         },
         "string-width": {
           "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59251,18 +61109,24 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "strip-ansi": {
               "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59274,12 +61138,16 @@
         },
         "stringify-package": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
+          "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59289,18 +61157,24 @@
         },
         "strip-eof": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "supports-color": {
           "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59310,6 +61184,8 @@
         },
         "tar": {
           "version": "4.4.13",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59325,6 +61201,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59337,6 +61215,8 @@
         },
         "term-size": {
           "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59346,18 +61226,24 @@
         },
         "text-table": {
           "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "through": {
           "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "through2": {
           "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59368,6 +61254,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59383,6 +61271,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59394,18 +61284,24 @@
         },
         "timed-out": {
           "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz",
+          "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "tough-cookie": {
           "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59416,6 +61312,8 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59425,6 +61323,8 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -59432,24 +61332,32 @@
         },
         "typedarray": {
           "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "uid-number": {
           "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "umask": {
           "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
+          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "unique-filename": {
           "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+          "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59459,6 +61367,8 @@
         },
         "unique-slug": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+          "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59468,6 +61378,8 @@
         },
         "unique-string": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59477,18 +61389,24 @@
         },
         "unpipe": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "unzip-response": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "update-notifier": {
           "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
+          "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59507,6 +61425,8 @@
         },
         "uri-js": {
           "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+          "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59516,6 +61436,8 @@
           "dependencies": {
             "punycode": {
               "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+              "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
               "bundled": true,
               "dev": true,
               "peer": true
@@ -59524,6 +61446,8 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59533,18 +61457,24 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "util-extend": {
           "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+          "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "util-promisify": {
           "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
+          "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59554,12 +61484,16 @@
         },
         "uuid": {
           "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59570,6 +61504,8 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59579,6 +61515,8 @@
         },
         "verror": {
           "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59590,6 +61528,8 @@
         },
         "wcwidth": {
           "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+          "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59599,6 +61539,8 @@
         },
         "which": {
           "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59608,12 +61550,16 @@
         },
         "which-module": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "wide-align": {
           "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59623,6 +61569,8 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59636,6 +61584,8 @@
         },
         "widest-line": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+          "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59645,6 +61595,8 @@
         },
         "worker-farm": {
           "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+          "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59654,6 +61606,8 @@
         },
         "wrap-ansi": {
           "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59665,18 +61619,24 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "string-width": {
               "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59688,6 +61648,8 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59699,12 +61661,16 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59716,30 +61682,40 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "xtend": {
           "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "y18n": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "yallist": {
           "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "bundled": true,
           "dev": true,
           "peer": true
         },
         "yargs": {
           "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59759,12 +61735,16 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "find-up": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59774,12 +61754,16 @@
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "locate-path": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59790,6 +61774,8 @@
             },
             "p-limit": {
               "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59799,6 +61785,8 @@
             },
             "p-locate": {
               "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59808,12 +61796,16 @@
             },
             "p-try": {
               "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
               "bundled": true,
               "dev": true,
               "peer": true
             },
             "string-width": {
               "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59825,6 +61817,8 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "bundled": true,
               "dev": true,
               "peer": true,
@@ -59836,6 +61830,8 @@
         },
         "yargs-parser": {
           "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
           "bundled": true,
           "dev": true,
           "peer": true,
@@ -59846,6 +61842,8 @@
           "dependencies": {
             "camelcase": {
               "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
               "bundled": true,
               "dev": true,
               "peer": true

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "babel-plugin-inline-package-json": "2.0.0",
     "babel-plugin-transform-es2017-object-entries": "0.0.5",
     "browserslist": "4.7.0",
+    "browserslist-browserstack": "^3.1.1",
     "common-tags": "1.8.0",
     "conventional-changelog-conventionalcommits": "4.6.0",
     "cross-env": "7.0.3",


### PR DESCRIPTION
This PR uses `browserlist-browserstack` to automatically pull in the latest BrowserStack capabilities for testing with Karma. Previously, the supported browsers had to be manually defined and updated. After this commit, we can request an updated array of capabilities from BrowserStack via their "Automate" API.

We use the result of that API call to filter the browserlist query results by what's actually supported by BrowserStack for Karma testing.

``` js
// this package will 
// 1) query browserlist 
// 2) query browserstack 
// 3) filter the result by what's supported
const mapBrowsersListToBrowserStackLaunchers = async () => {
  return await browserList_browserStack
    .default({
      username: process.env.BROWSERSTACK_USERNAME,
      accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
      browserslist: {
        queries: [
          "ie >= 11",
          "last 1 Android versions",
          "last 1 Chrome versions",
          "last 1 Firefox versions",
          "last 1 Safari versions",
          "last 1 iOS versions",
          "last 1 Edge versions",
          "last 1 Opera versions",
        ], // TODO: pull in the package.json version
      },
      formatForSelenium: false,
    })
     // here we format the result for use with karma using a helper
    .then((res) => {
      return formatForKarma(res, "BrowserStack");
    });
};
```

This PR also adds a small change to the BrowserStack config where all the tests of a karma run are now grouped under an identifier

``` js
browserStack: {
      username: process.env.BROWSERSTACK_USERNAME,
      accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
      build: `react-imgix-bs-${new Date().toLocaleDateString()}`, // this avoids single test run noise by grouping the results
    },
```