### PR TITLE
chore: use openssl legacy provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ addons:
   chrome: beta
   firefox: latest
 
-node_js:
-  - lts/*
-  - stable
+jobs:
+  include:
+  - node: lts/*
+  - node: stable
+    env: NODE_OPTIONS=--openssl-legacy-provider
 
 script:
   - travis_retry npm test


### PR DESCRIPTION
On node/stable builds, the following error occurs:

[karma-server]: UnhandledRejection: error:0308010C:digital envelope routines::unsupported

Currently, the most accepted answer (https://github.com/webpack/webpack/issues/14532#issuecomment-947012063) to fix this is to use the legacy version of openssl for non-LTS node versions.