### PR TITLE
docs: add devicePixelRatios to SHARED_IMGIX_AND_SOURCE_PROP_TYPES

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,7 +689,7 @@ Disable generation of variable `q` parameters when rendering a fixed-size image.
 
 ##### srcSetOptions :: object
 
-Allows customizing the behavior of the srcset generation. Valid options are `widths`, `widthTolerance`, `minWidth`, and `maxWidth`. See [@imgix/js-core](https://github.com/imgix/js-core#imgixclientbuildsrcsetpath-params-options) for documentation of these options.
+Allows customizing the behavior of the srcset generation. Valid options are `widths`, `widthTolerance`, `minWidth`, `maxWidth`, and `devicePixelRatios`. See [@imgix/js-core](https://github.com/imgix/js-core#imgixclientbuildsrcsetpath-params-options) for documentation of these options.
 
 #### Picture Props
 

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -50,6 +50,7 @@ const SHARED_IMGIX_AND_SOURCE_PROP_TYPES = Object.assign(
       widthTolerance: PropTypes.number,
       minWidth: PropTypes.number,
       maxWidth: PropTypes.number,
+      devicePixelRatios: PropTypes.arrayOf(PropTypes.number),
     }),
   }
 );


### PR DESCRIPTION
## Description

Right now the prop types do not include devicePixelRatios in srcSetOptions but it does work.

