### PR TITLE
feat: add alt top level prop

### DIFF
--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -31,6 +31,7 @@ const COMMON_PROP_TYPES = {
   className: PropTypes.string,
   onMounted: PropTypes.func,
   htmlAttributes: PropTypes.object,
+  alt: PropTypes.string,
 };
 
 const SHARED_IMGIX_AND_SOURCE_PROP_TYPES = Object.assign(
@@ -54,6 +55,14 @@ const SHARED_IMGIX_AND_SOURCE_PROP_TYPES = Object.assign(
     }),
   }
 );
+
+const REACT_IMGIX_PROP_TYPES = Object.assign(
+  {},
+  SHARED_IMGIX_AND_SOURCE_PROP_TYPES,
+  {
+    alt: PropTypes.string,
+  });
+
 
 /**
  * Validates that an aspect ratio is in the format w:h. If false is returned, the aspect ratio is in the wrong format.
@@ -178,7 +187,7 @@ function imgixParams(props) {
  * React component used to render <img> elements with Imgix
  */
 class ReactImgix extends Component {
-  static propTypes = Object.assign({}, SHARED_IMGIX_AND_SOURCE_PROP_TYPES);
+  static propTypes = Object.assign({}, REACT_IMGIX_PROP_TYPES);
   static defaultProps = {
     disableSrcSet: false,
     onMounted: noop,
@@ -240,6 +249,9 @@ class ReactImgix extends Component {
     });
     if (!disableSrcSet) {
       childProps[attributeConfig.srcSet] = srcSet;
+    }
+    if (this.props.alt) { 
+      childProps.alt = this.props.alt;
     }
 
     return <img {...childProps} />;

--- a/test/unit/attributes.test.js
+++ b/test/unit/attributes.test.js
@@ -1,0 +1,30 @@
+import { mount } from "enzyme";
+import React from "react";
+import ReactImgix from "../../src/index";
+
+const imageProps = {
+  src: "https://assets.imgix.net/examples/pione.jpg",
+  sizes: "50vw",
+  disableSrcSet: true,
+  disableLibraryParam: true,
+};
+
+describe("ReactImgix", () => {
+  test("should set alt prop on the react component", () => {
+    const component = <ReactImgix {...imageProps} alt="a cute dog" />;
+
+    const expectedImageTagProps = {
+      alt: "a cute dog",
+      sizes: "50vw",
+      className: undefined,
+      width: undefined,
+      height: undefined,
+      src: "https://assets.imgix.net/examples/pione.jpg?auto=format",
+    };
+
+    const renderedComponent = mount(component);
+    const renderedImageTagProps = renderedComponent.find("img").props();
+
+    expect(renderedImageTagProps).toEqual(expectedImageTagProps);
+  });
+});


### PR DESCRIPTION
## Before this PR
The `alt` attribute had to be set by making use of the `htmlAttributes` prop.

## After this PR
The `alt` attribute can be set using a top-level `alt` prop.