### PR TITLE
feat: allow path encoding to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,10 @@ Disable generation of variable width src sets to enable responsiveness.
 
 By default this component adds a parameter to the generated url to help imgix with analytics and support for this library. This can be disabled by setting this prop to `true`.
 
+##### disablePathEncoding :: bool
+
+By default this component encodes the url path in the src and srcSet. This can be disabled by setting this prop to `true`. For more information about how imgix path encoding works, please refer to the [imgix/js-core](https://github.com/imgix/js-core#disable-path-encoding) docs.
+
 ##### htmlAttributes :: object
 
 Any other attributes to add to the html node (example: `alt`, `data-*`, `className`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -4311,11 +4311,11 @@
       "dev": true
     },
     "node_modules/@imgix/js-core": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@imgix/js-core/-/js-core-3.1.3.tgz",
-      "integrity": "sha512-7HUIFy4dq9wLSJURgPhglSni50rt3af4cAyBip14koR5oPIGgTGs0W41aQZc5gyCesh7jZaSjm4VxiwqS7gszw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@imgix/js-core/-/js-core-3.5.0.tgz",
+      "integrity": "sha512-rUbvZBzGa9dFcoHqyzDA1Ag3kpEDKuKilpQS8XqUqTH6zpPw16922e8ciKFfxKfHdqMvC/yaYIE1HYo5MxzWvA==",
       "dependencies": {
-        "js-base64": "~2.6.0",
+        "js-base64": "~3.7.0",
         "md5": "^2.2.1"
       }
     },
@@ -20890,9 +20890,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
     },
     "node_modules/js-tokens": {
       "version": "3.0.2",
@@ -37682,11 +37682,11 @@
       "dev": true
     },
     "@imgix/js-core": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@imgix/js-core/-/js-core-3.1.3.tgz",
-      "integrity": "sha512-7HUIFy4dq9wLSJURgPhglSni50rt3af4cAyBip14koR5oPIGgTGs0W41aQZc5gyCesh7jZaSjm4VxiwqS7gszw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@imgix/js-core/-/js-core-3.5.0.tgz",
+      "integrity": "sha512-rUbvZBzGa9dFcoHqyzDA1Ag3kpEDKuKilpQS8XqUqTH6zpPw16922e8ciKFfxKfHdqMvC/yaYIE1HYo5MxzWvA==",
       "requires": {
-        "js-base64": "~2.6.0",
+        "js-base64": "~3.7.0",
         "md5": "^2.2.1"
       }
     },
@@ -51023,9 +51023,9 @@
       }
     },
     "js-base64": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
     },
     "js-tokens": {
       "version": "3.0.2",

--- a/src/constructUrl.js
+++ b/src/constructUrl.js
@@ -6,8 +6,8 @@ Minor syntax modifications have been made
 */
 
 const PACKAGE_VERSION = require("../package.json").version;
-import extractQueryParams from "./extractQueryParams";
 import ImgixClient from "@imgix/js-core";
+import extractQueryParams from "./extractQueryParams";
 
 // @see https://www.imgix.com/docs/reference
 var PARAM_EXPANSION = Object.freeze({
@@ -110,28 +110,28 @@ var DEFAULT_OPTIONS = Object.freeze({
  * Construct a URL for an image with an Imgix proxy, expanding image options
  * per the [API reference docs](https://www.imgix.com/docs/reference).
  * @param  {String} src         src of raw image
- * @param  {Object} longOptions map of image API options, in long or short form per expansion rules
+ * @param  {Object} longImgixParams map of image API options, in long or short form per expansion rules
  * @return {String}             URL of image src transformed by Imgix
  */
-function constructUrl(src, longOptions) {
+function constructUrl(src, longImgixParams, srcOptions) {
   if (!src) {
     return "";
   }
-  const params = compactParamKeys(longOptions);
+  const params = compactParamKeys(longImgixParams);
   const { client, pathComponents } = extractClientAndPathComponents(src);
-  return client.buildURL(pathComponents.join("/"), params);
+  return client.buildURL(pathComponents.join("/"), params, srcOptions);
 }
 
-function compactParamKeys(longOptions) {
-  const keys = Object.keys(longOptions);
+function compactParamKeys(longImgixParams) {
+  const keys = Object.keys(longImgixParams);
   const keysLength = keys.length;
   const params = {};
   for (let i = 0; i < keysLength; i++) {
     let key = keys[i];
     if (PARAM_EXPANSION[key]) {
-      params[PARAM_EXPANSION[key]] = longOptions[key];
+      params[PARAM_EXPANSION[key]] = longImgixParams[key];
     } else {
-      params[key] = longOptions[key];
+      params[key] = longImgixParams[key];
     }
   }
 

--- a/test/unit/encoding.test.js
+++ b/test/unit/encoding.test.js
@@ -1,6 +1,6 @@
 import { mount } from "enzyme";
 import React from "react";
-import ReactImgix, { Source } from "../../src/index";
+import ReactImgix, { ImgixProvider, Source } from "../../src/index";
 
 const imageProps = {
   src: "https://assets.imgix.net/examples/space bridge.jpg",
@@ -45,6 +45,23 @@ describe("ReactImgix", () => {
     const renderedComponent = mount(component);
     const renderedImageTagProps = renderedComponent.find("img").props();
 
+    expect(renderedImageTagProps.srcSet).toMatch(expectedSrc);
+  });
+  it("should not encode the src or srcset path if disablePathEncoding is set on <ImgixProvider>", () => {
+    const providerProps = {
+      disablePathEncoding: true,
+    };
+    const wrappedComponent = (
+      <ImgixProvider {...providerProps}>
+        <ReactImgix {...imageProps} />
+      </ImgixProvider>
+    );
+
+    const expectedSrc = "https://assets.imgix.net/examples/space bridge.jpg";
+
+    const renderedComponent = mount(wrappedComponent);
+    const renderedImageTagProps = renderedComponent.find("img").props();
+    expect(renderedImageTagProps.src).toMatch(expectedSrc);
     expect(renderedImageTagProps.srcSet).toMatch(expectedSrc);
   });
 });

--- a/test/unit/encoding.test.js
+++ b/test/unit/encoding.test.js
@@ -1,0 +1,50 @@
+import { mount } from "enzyme";
+import React from "react";
+import ReactImgix from "../../src/index";
+
+const imageProps = {
+  src: "https://assets.imgix.net/examples/space bridge.jpg",
+};
+
+describe("ReactImgix", () => {
+  test("should encode src path", () => {
+    const component = <ReactImgix {...imageProps} />;
+
+    const expectedSrc = "https://assets.imgix.net/examples/space%20bridge.jpg";
+
+    const renderedComponent = mount(component);
+    const renderedImageTagProps = renderedComponent.find("img").props();
+
+    expect(renderedImageTagProps.src).toMatch(expectedSrc);
+  });
+  test("should not encode the src path if disablePathEncoding is set to true", () => {
+    const component = <ReactImgix {...imageProps} disablePathEncoding />;
+
+    const expectedSrc = "https://assets.imgix.net/examples/space bridge.jpg";
+
+    const renderedComponent = mount(component);
+    const renderedImageTagProps = renderedComponent.find("img").props();
+
+    expect(renderedImageTagProps.src).toMatch(expectedSrc);
+  });
+  test("should encode the srcset", () => {
+    const component = <ReactImgix {...imageProps} />;
+
+    const expectedSrc = "https://assets.imgix.net/examples/space%20bridge.jpg";
+
+    const renderedComponent = mount(component);
+    const renderedImageTagProps = renderedComponent.find("img").props();
+
+    expect(renderedImageTagProps.srcSet).toMatch(expectedSrc);
+  });
+  test("should not encode the srcset if disablePathEncoding is set to true", () => {
+    const component = <ReactImgix {...imageProps} disablePathEncoding />;
+
+    const expectedSrc = "https://assets.imgix.net/examples/space bridge.jpg";
+
+    const renderedComponent = mount(component);
+    const renderedImageTagProps = renderedComponent.find("img").props();
+
+    expect(renderedImageTagProps.srcSet).toMatch(expectedSrc);
+  });
+});

--- a/test/unit/encoding.test.js
+++ b/test/unit/encoding.test.js
@@ -1,6 +1,6 @@
 import { mount } from "enzyme";
 import React from "react";
-import ReactImgix from "../../src/index";
+import ReactImgix, { Source } from "../../src/index";
 
 const imageProps = {
   src: "https://assets.imgix.net/examples/space bridge.jpg",
@@ -46,5 +46,49 @@ describe("ReactImgix", () => {
     const renderedImageTagProps = renderedComponent.find("img").props();
 
     expect(renderedImageTagProps.srcSet).toMatch(expectedSrc);
+  });
+});
+describe("Source", () => {
+  test("should encode srcSet path", () => {
+    const component = <Source {...imageProps} />;
+
+    const expectedSrc = "https://assets.imgix.net/examples/space%20bridge.jpg";
+
+    const renderedComponent = mount(component);
+    const renderedSourceTagProps = renderedComponent.find("source").props();
+
+    expect(renderedSourceTagProps.srcSet).toMatch(expectedSrc);
+  });
+  test("should not encode the srcSet path if disablePathEncoding is set to true", () => {
+    const component = <Source {...imageProps} disablePathEncoding />;
+
+    const expectedSrc = "https://assets.imgix.net/examples/space bridge.jpg";
+
+    const renderedComponent = mount(component);
+    const renderedSourceTagProps = renderedComponent.find("source").props();
+
+    expect(renderedSourceTagProps.srcSet).toMatch(expectedSrc);
+  });
+  test("should encode the srcset path if disableSrcSet is true", () => {
+    const component = <Source {...imageProps} disableSrcSet />;
+
+    const expectedSrc = "https://assets.imgix.net/examples/space%20bridge.jpg";
+
+    const renderedComponent = mount(component);
+    const renderedSourceTagProps = renderedComponent.find("source").props();
+
+    expect(renderedSourceTagProps.srcSet).toMatch(expectedSrc);
+  });
+  test("should not encode the srcset path if disablePathEncoding and disableSrcSet are set to true", () => {
+    const component = (
+      <Source {...imageProps} disableSrcSet disablePathEncoding />
+    );
+
+    const expectedSrc = "https://assets.imgix.net/examples/space bridge.jpg";
+
+    const renderedComponent = mount(component);
+    const renderedSourceTagProps = renderedComponent.find("source").props();
+
+    expect(renderedSourceTagProps.srcSet).toMatch(expectedSrc);
   });
 });


### PR DESCRIPTION
This PR exposes the feature to disable path encoding, that was recently added to js-core. This behaviour is exposed through a new `disablePathEncoding` prop. Information about this new prop can be found in the README. 

Closes #815
