### PR TITLE
chore: add gh issue action

### DIFF
--- a/.github/worklows/add-issue-to-project.yml
+++ b/.github/worklows/add-issue-to-project.yml
@@ -1,0 +1,19 @@
+name: Add issues to project
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/imgix/projects/4
+          github-token: ${{ secrets.GH_TOKEN }}
+          labeled: bug, needs-triage
+          label-operator: OR


### PR DESCRIPTION
This PR adds a GH Action to automatically add an issue tagged as `bug/need-triage` to the issues board.