### PR TITLE
fix: stop background infinite re-renders

### DIFF
--- a/src/react-imgix-bg.jsx
+++ b/src/react-imgix-bg.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { withContentRect } from "react-measure";
+import { shallowEqual } from "./common";
 import { PACKAGE_VERSION } from "./constants";
 import constructUrl from "./constructUrl";
 import extractQueryParams from "./extractQueryParams";
 import findClosest from "./findClosest";
 import targetWidths from "./targetWidths";
-import { shallowEqual } from "./common";
 
 const findNearestWidth = (actualWidth) =>
   findClosest(actualWidth, targetWidths);
@@ -42,7 +42,7 @@ export const __shouldComponentUpdate = (props, nextProps) => {
 
   const customizer = (oldProp, newProp, key) => {
     // these keys are ignored from prop checking process
-    if (key === "contextRect" || key === "measure" || key === "measureRef") {
+    if (key === "contentRect" || key === "measure" || key === "measureRef") {
       return true;
     }
 


### PR DESCRIPTION
## Description

Before this commit, a spelling error made it so `_shouldComponentUpdate` always returned true, causing infinite re-renders. After this commit, the `<Background />` component should only render a maximim of 4 times.

The `contentRect` prop comes from `react-measure`. It changes every time the component re-renders. Because `shouldComponentUpdate()` detects the change, it returns true, and the cycle repeats itself.

The spelling error prevents us from adding this to the "allow-list" of props to not re-render for.

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

1. `npm run build`
2. link the package in a react application
3. use the react dev tools profiler to see the render counts
4. observe how after this change the re-rendering issue goes away


Related PR: #793

Code:

```diff
-    if (key === "contenxtRect" || key === "measure" || key === "measureRef") {
+    if (key === "contentRect" || key === "measure" || key === "measureRef") {
```
