### PR TITLE
ci: add build test to circleci steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ jobs:
             - run: echo 'export NODE_OPTIONS=--openssl-legacy-provider' >> $BASH_ENV
       - node/install-packages
       - run: npm run test
+      - run:
+          name: "Test whether build is successful"
+          command: yarn build
   deploy:
     docker:
       - image: cimg/node:17.9


### PR DESCRIPTION
Adds an additional test step to our CircleCI process to test successful builds.

# Before

Problems with builds can only be detected by CircleCI during the `deploy` step; this step only runs on `main` and prerelease branches. As a result, commits that break builds (included automated dependency updates by Renovate) in many cases might not be detected until after merge.
# After

We now test for a successful `build` step on every branch.