### PR TITLE
fix: source width/height HTML validation

### DIFF
--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -383,8 +383,8 @@ class SourceImpl extends Component {
     const childProps = Object.assign({}, this.props.htmlAttributes, {
       [attributeConfig.sizes]: this.props.sizes,
       className: this.props.className,
-      width: width <= 1 ? null : width,
-      height: height <= 1 ? null : height,
+      width: null,
+      height: null,
       ref: (el) => {
         this.sourceRef = el;
         if (

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -337,6 +337,7 @@ describe("When in <source> mode", () => {
         <Source
           src={src}
           width={100}
+          height={100}
           htmlAttributes={htmlAttributes}
           sizes={sizes}
         />
@@ -356,6 +357,12 @@ describe("When in <source> mode", () => {
       expect(srcSets[2].split(" ")[1]).toBe("3x");
       expect(srcSets[3].split(" ")[1]).toBe("4x");
       expect(srcSets[4].split(" ")[1]).toBe("5x");
+    });
+
+    it("width and height should be nullable to pass HTML validation", () => {
+      const {width, height} = renderImage().props();
+      expect(width).toBe(null);
+      expect(height).toBe(null);
     });
   });
 


### PR DESCRIPTION
(cherry picked from commit e58464c7038ef013b2d54c35aa086fbd9016d998)

<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description
related issue: #860 
related pr: #861

fixes issue HTML source tag failing the validation due to width/height presence in DOM

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->

<!-- After this PR... -->

<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->

## Checklist
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] All existing unit tests are still passing (if applicable).
- [x] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [x] Add new passing unit tests to cover the code introduced by your PR (if applicable).