### PR TITLE
fix(background): disable path encoding

### DIFF
--- a/src/react-imgix-bg.jsx
+++ b/src/react-imgix-bg.jsx
@@ -89,6 +89,7 @@ class BackgroundImpl extends React.Component {
       imgixParams = {},
       onLoad,
       disableLibraryParam,
+      disablePathEncoding,
       src,
       children,
       className = "",
@@ -154,7 +155,7 @@ class BackgroundImpl extends React.Component {
 
     const renderedSrc = (() => {
       const [rawSrc, params] = extractQueryParams(src);
-      const srcOptions = {
+      const longImgixParams = {
         ...params,
         fit: "crop",
         ...imgixParams,
@@ -164,7 +165,11 @@ class BackgroundImpl extends React.Component {
         dpr,
       };
 
-      return constructUrl(rawSrc, srcOptions);
+      const srcOptions = {
+        disablePathEncoding,
+      }
+
+      return constructUrl(rawSrc, longImgixParams, srcOptions);
     })();
 
     const style = {

--- a/test/unit/encoding.test.js
+++ b/test/unit/encoding.test.js
@@ -1,6 +1,6 @@
 import { mount } from "enzyme";
 import React from "react";
-import ReactImgix, { ImgixProvider, Source } from "../../src/index";
+import ReactImgix, { ImgixProvider, Source, Background } from "../../src/index";
 
 const imageProps = {
   src: "https://assets.imgix.net/examples/space bridge.jpg",
@@ -27,6 +27,33 @@ describe("ReactImgix", () => {
 
     expect(renderedImageTagProps.src).toMatch(expectedSrc);
   });
+
+  test("Background should not encode the src path if disablePathEncoding is set to true", () => {
+    const encodedSrc =
+      "https://sdk-test.imgix.net/%26%24%2B%2C%3A%3B%3D%3F%40%23.jpg";
+    // Force BG to render immediately by giving it w,h params, contentRect bounds
+    // and a measureRef that points to null
+    const component = (
+      <Background
+        className="bg-test"
+        src={encodedSrc}
+        disablePathEncoding
+        disableLibraryParam
+        measureRef={() => null}
+        imgixParams={{ w: 100, h: 100 }}
+        contentRect={{ bounds: { top: 10, width: 100, height: 100 } }}
+      >
+        <div>Content</div>
+      </Background>
+    );
+    const expectedBgUrl = `url(${encodedSrc}?fit=crop&w=100&h=100&dpr=1)`;
+
+    const renderedComponent = mount(component);
+    const renderedBg = renderedComponent.find("div.bg-test").props();
+
+    expect(renderedBg.style.backgroundImage).toMatch(expectedBgUrl);
+  });
+
   test("should encode the srcset", () => {
     const component = <ReactImgix {...imageProps} />;
 


### PR DESCRIPTION
<!--
Hello, and thanks for contributing 🎉🙌
Please take a second to fill out PRs with the following template!
-->

## Description
This PR fixes an issue where the `<Background />` component did not disable path encoding when the `disablePathEncoding` prop was set.

Related issue: #863

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

<!-- Before this PR... -->
## Before
`disablePathEncoding` in `<Background>` did nothing.
<!-- After this PR... -->
## After
Disable path encoding in `<Background>` does not over-encode the filepath.
<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->

## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] All existing unit tests are still passing (if applicable).

<!-- For new feature and bugfix Pull Requests-->
- [x] Add new passing unit tests to cover the code introduced by your PR (if applicable).

## Future work
- [x] create unit test
- [x] ensure background component respects `disablePathEncoding`

```bash
    expect(received).toMatch(expected)

    Expected substring: "url(https://sdk-test.imgix.net/%26%24%2B%2C%3A%3B%3D%3F%40%23.jpg?fit=crop&w=100&h=100&dpr=1)"
    Received string:    "url(https://sdk-test.imgix.net/%2526%2524%252B%252C%253A%253B%253D%253F%2540%2523.jpg?fit=crop&w=100&h=100&dpr=1)"
```