### PR TITLE
feat: add use client directive to index

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ In this example, Imgix will produce a srcset with width descriptors.
 
 #### Server-Side Rendering
 
+> Note
+This library does not run in Server Components but instead adds the ["use client" directive](https://react.dev/reference/react/use-client) to components. This means they are able to be used alongside Server Components (for example, as children), but they still require client-side JavaScript. [Client Components are still SSRed](https://github.com/reactwg/server-components/discussions/4).
+
 React-imgix also works well on the server. Since react-imgix uses `srcset` and `sizes`, it allows the browser to render the correctly sized image immediately after the page has loaded.
 If they are known, pass width and height attributes via `htmlAttributes` to help combat layout shift.
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+'use client';
+
 import ReactImgix, { Picture, Source } from "./react-imgix";
 import { PublicConfigAPI } from "./config";
 import { buildURLPublic as buildURL } from "./constructUrl";


### PR DESCRIPTION
## Description

<!-- What is accomplished by this PR? If there is something potentially
controversial in your PR, please take a moment to tell us about your choices.-->

This PR adds the `"use client"` directive to the components index file.

<!-- Before this PR... -->
Before this PR, consumer who didn't add `"use client"` in a file or wrapper where `<Imgix>` was used would see a build error in NextJs 13.

<!-- After this PR... -->
After this PR, consumers no longer see this error, and can use `<Imgix>`, `<Picture>`, and `<Background>` as client components, and, critically, as children of server only components.

<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->

## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [x] Update or add any necessary API documentation (if applicable)
- [x] All existing unit tests are still passing (if applicable).