### PR TITLE
[PE-4862] Updates background component to merge props

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: yarn build
   deploy:
     docker:
-      - image: cimg/node:20.4
+      - image: cimg/node:21.4
     steps:
       - checkout
       - node/install-packages

--- a/src/react-imgix-bg.jsx
+++ b/src/react-imgix-bg.jsx
@@ -6,6 +6,7 @@ import constructUrl from "./constructUrl";
 import extractQueryParams from "./extractQueryParams";
 import findClosest from "./findClosest";
 import targetWidths from "./targetWidths";
+import { mergeComponentPropsHOF, processPropsHOF } from "./HOFs";
 
 const findNearestWidth = (actualWidth) =>
   findClosest(actualWidth, targetWidths);
@@ -188,6 +189,9 @@ class BackgroundImpl extends React.Component {
     );
   }
 }
-const Background = withContentRect("bounds")(BackgroundImpl);
+
+const Background = mergeComponentPropsHOF(
+  processPropsHOF(withContentRect("bounds")(BackgroundImpl))
+);
 
 export { Background, BackgroundImpl as __BackgroundImpl };


### PR DESCRIPTION
## Description
This PR address [issue](https://github.com/imgix/react-imgix/issues/931): Background component doesn't utilize ImgixProvider's domain parameter
 - `mergeComponentPropsHOF` and `processPropsHOF` now wrap `withContentRect("bounds")(BackgroundImpl)`
 
**BEFORE:**
Imgix domain prop was not being passed to Background component from ImgixProvider
```js
 <ImgixProvider domain={IMGIX_DOMAIN}>
      <Imgix
        src="image.jpg"
        width={100}
      /> {/* The Imgix component successfully uses the domain from the Provider */}
      <Background src="image.png" className="blog-title">
        <h2>Blog Title</h2>
      </Background> {/* The Background component fails to utilize the domain from the Provider */}
 </ImgixProvider>
```

**AFTER:**
Imgix domain prop can be access by Background component from ImgixProvider


## How to test:
It takes a little set up to test, you'll need to add `react-imgix` to a repo and link to the working branch:
1. create a react app `yarn create vite my-react-app --template react`
2. CD into `react-imgix` and pull this branch, run `npm run build`
4. CD into newly created `my-react-app`: `yarn link react-imgix`
5. In `my-react-app` run: `yarn dev`
6. Replace `App.jsx` with this code snippet:
```js
import './App.css';
import Imgix, { Background, ImgixProvider } from 'react-imgix';

function App() {
  return (
    <>
      <ImgixProvider domain={IMGIX_DOMAIN}>
        <Imgix
          src='cats2.jpeg'
          width={500}
        />
        <Background
          src='lion.jpeg'
          className='blog-title'
        >
          <h2>Background Using ImgixProvider Domain</h2>
        </Background>
      </ImgixProvider>
    </>
  );
}

export default App;

```
7. Expect to see all Images loading correctly on http://localhost:5173/
8. Alternatively, see video of images, logging and changes:

https://github.com/imgix/react-imgix/assets/49009626/2c23a89e-fea1-4a2b-9f69-d77b0bb72d88

