### PR TITLE
fix(readme):remove html encoding from parameter strings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@5.1.0
-  browser-tools: circleci/browser-tools@1.4.5 # see https://github.com/CircleCI-Public/browser-tools-orb/issues/33#issuecomment-1081974320 and https://github.com/cypress-io/circleci-orb/issues/437
+  browser-tools: circleci/browser-tools@1.4.6 # see https://github.com/CircleCI-Public/browser-tools-orb/issues/33#issuecomment-1081974320 and https://github.com/cypress-io/circleci-orb/issues/437
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@5.1.0
-  browser-tools: circleci/browser-tools@1.4.3 # see https://github.com/CircleCI-Public/browser-tools-orb/issues/33#issuecomment-1081974320
+  browser-tools: circleci/browser-tools@1.4.5 # see https://github.com/CircleCI-Public/browser-tools-orb/issues/33#issuecomment-1081974320 and https://github.com/cypress-io/circleci-orb/issues/437
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@5.1.0
-  browser-tools: circleci/browser-tools@1.4.6 # see https://github.com/CircleCI-Public/browser-tools-orb/issues/33#issuecomment-1081974320 and https://github.com/cypress-io/circleci-orb/issues/437
+  browser-tools: circleci/browser-tools@1.4.8 # see https://github.com/CircleCI-Public/browser-tools-orb/issues/33#issuecomment-1081974320 and https://github.com/cypress-io/circleci-orb/issues/437
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ This will generate HTML similar to the following:
 
 ```html
 <img
-  src="https://assets.imgix.net/examples/pione.jpg?auto=format&amp;crop=faces&amp;ixlib=react-7.2.0"
+  src="https://assets.imgix.net/examples/pione.jpg?auto=format&crop=faces&ixlib=react-7.2.0"
   sizes="100vw"
   srcset="
-    https://assets.imgix.net/examples/pione.jpg?auto=format&amp;crop=faces&amp;ixlib=react-7.2.0&amp;w=100 100w,
-    https://assets.imgix.net/examples/pione.jpg?auto=format&amp;crop=faces&amp;ixlib=react-7.2.0&amp;w=200 200w,
+    https://assets.imgix.net/examples/pione.jpg?auto=format&crop=faces&ixlib=react-7.2.0&w=100 100w,
+    https://assets.imgix.net/examples/pione.jpg?auto=format&crop=faces&ixlib=react-7.2.0&w=200 200w,
     ...
   "
 />


### PR DESCRIPTION
## Description
Correct readme instructions to use "&" instead of "&amp;" to chain parameters.
Same for output HTML code snippets.