### PR TITLE
fix: forward disablePathEncoding bool to consctructUrl call

### DIFF
--- a/src/constructUrl.js
+++ b/src/constructUrl.js
@@ -164,7 +164,8 @@ function buildURLPublic(src, imgixParams = {}, options = {}) {
       params,
       imgixParams,
       disableLibraryParam ? {} : { ixlib: `react-${PACKAGE_VERSION}` }
-    )
+    ),
+    { disablePathEncoding }
   );
 }
 

--- a/src/constructUrl.js
+++ b/src/constructUrl.js
@@ -153,7 +153,7 @@ function extractClientAndPathComponents(src) {
 }
 
 function buildURLPublic(src, imgixParams = {}, options = {}) {
-  const { disableLibraryParam } = options;
+  const { disableLibraryParam, disablePathEncoding } = options;
 
   const [rawSrc, params] = extractQueryParams(src);
 


### PR DESCRIPTION


## Description

Per https://github.com/imgix/react-imgix/issues/949, disablePathEncoding parameter doesn't do anything right now.

<!-- Before this PR... -->
disablePathEncoding: true will still encode the path

<!-- After this PR... -->
disablePathEncoding: true will not encode the path

## Checklist

<!-- For all Pull Requests -->

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [x] Update or add any necessary API documentation (if applicable)
- [x] All existing unit tests are still passing (if applicable).

<!-- For new feature and bugfix Pull Requests-->

- [x] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [x] Add new passing unit tests to cover the code introduced by your PR (if applicable).
- [x] Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.
- [x] If this is a big feature with breaking changes, consider opening an issue to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
