### PR TITLE
feat: add sizes=auto fallback to lazy-loaded images

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,7 +585,23 @@ For example, if the the developer would like to attach a custom `onLoad` callbac
 
 #### Lazy Loading
 
-If you'd like to lazy load images, we recommend using [lazysizes](https://github.com/aFarkas/lazysizes). In order to use react-imgix with lazysizes, you can simply tell it to generate lazysizes-compatible attributes instead of the standard `src`, `srcset`, and `sizes` by changing some configuration settings:
+If you'd like to lazy load images, we recommend using browser-level lazy loading, with the [`loading`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/loading) property, passed in `htmlAttributes`:
+
+```jsx
+<Imgix
+  src="..."
+  sizes="..."
+  htmlAttributes={{
+    loading: "lazy"
+  }}
+/>
+```
+
+This property has [strong browser support](https://caniuse.com/loading-lazy-attr), and functions without additional JavaScript. Additionally, using browser-level lazy loading enables optimization of the sizes attribute with `sizes="auto"`, which allows the browser to [automatically calculate the optimal size](https://ericportis.com/posts/2023/auto-sizes-pretty-much-requires-width-and-height/) for the image based on its layout. 
+
+If you need granular control over lazy-loading behavior such as loading distance, you can use the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API).
+
+If you are using a library like [lazysizes](https://github.com/aFarkas/lazysizes), you can tell the Imgix component to generate compatible attributes instead of the standard `src`, `srcset`, and `sizes` by changing some configuration settings:
 
 ```jsx
 <Imgix

--- a/src/react-imgix.jsx
+++ b/src/react-imgix.jsx
@@ -244,8 +244,18 @@ class ReactImgix extends Component {
       defaultAttributeMap,
       this.props.attributeConfig
     );
+
+    const fixedSize = !!(
+      (width || this.props.htmlAttributes?.width) &&
+      (height || this.props.htmlAttributes?.height)
+    );
+    let adjustedSizes = this.props.sizes;
+    if (this.props.sizes && this.props.htmlAttributes?.loading === "lazy" && !fixedSize) {
+      adjustedSizes = "auto, " + adjustedSizes ?? "";
+    }
+
     const childProps = Object.assign({}, this.props.htmlAttributes, {
-      [attributeConfig.sizes]: this.props.sizes,
+      [attributeConfig.sizes]: adjustedSizes,
       className: this.props.className,
       width: width <= 1 ? null : width ?? this.props.htmlAttributes?.width,
       height: height <= 1 ? null : height ?? this.props.htmlAttributes?.height,

--- a/test/unit/react-imgix.test.jsx
+++ b/test/unit/react-imgix.test.jsx
@@ -239,6 +239,7 @@ describe("When in default mode", () => {
         "data-src": "https://mysource.imgix.net/demo.png",
         width: "200",
         height: "100",
+        loading: "lazy"
       };
       sut = shallow(
         <Imgix
@@ -250,6 +251,89 @@ describe("When in default mode", () => {
       expect(sut.props()["data-src"]).toEqual(htmlAttributes["data-src"]);
       expect(sut.props()["width"]).toEqual(htmlAttributes["width"]);
       expect(sut.props()["height"]).toEqual(htmlAttributes["height"]);
+      expect(sut.props()["loading"]).toEqual(htmlAttributes["loading"]);
+    });
+    it("prepends 'auto, ' to the sizes prop if loading is lazy and not fixed size", () => {
+      const htmlAttributes = {
+        "data-src": "https://mysource.imgix.net/demo.png",
+        width: "200",
+        loading: "lazy",
+      };
+      sut = shallow(
+        <Imgix
+          src={"https://mysource.imgix.net/demo.png"}
+          sizes="100vw"
+          htmlAttributes={htmlAttributes}
+        />
+      );
+      expect(sut.props()["sizes"]).toEqual("auto, 100vw"); 
+    });
+  
+    it("does not prepend 'auto, ' to the sizes prop if loading is not lazy", () => {
+      const htmlAttributes = {
+        "data-src": "https://mysource.imgix.net/demo.png",
+        width: "200",
+        height: "100",
+        loading: "eager", // Not lazy loading
+      };
+      sut = shallow(
+        <Imgix
+          src={"https://mysource.imgix.net/demo.png"}
+          sizes="100vw"
+          htmlAttributes={htmlAttributes}
+        />
+      );
+      expect(sut.props()["sizes"]).toEqual("100vw"); 
+    });
+
+    it("does not prepend 'auto, ' to the sizes prop if loading is omitted", () => {
+      const htmlAttributes = {
+        "data-src": "https://mysource.imgix.net/demo.png",
+        width: "200",
+        height: "100",
+      };
+      sut = shallow(
+        <Imgix
+          src={"https://mysource.imgix.net/demo.png"}
+          sizes="100vw"
+          htmlAttributes={htmlAttributes}
+        />
+      );
+      expect(sut.props()["sizes"]).toEqual("100vw"); 
+    });
+
+    it("does not prepend 'auto, ' to the sizes prop if both width and height are present (htmlAttributes)", () => {
+      const htmlAttributes = {
+        "data-src": "https://mysource.imgix.net/demo.png",
+        width: "200",
+        height: "100",
+        loading: "lazy",
+      };
+      sut = shallow(
+        <Imgix
+          src={"https://mysource.imgix.net/demo.png"}
+          sizes="100vw"
+          htmlAttributes={htmlAttributes}
+        />
+      );
+      expect(sut.props()["sizes"]).toEqual("100vw"); 
+    });
+
+    it("does not prepend 'auto, ' to the sizes prop if both width and height are present (element attributes)", () => {
+      const htmlAttributes = {
+        "data-src": "https://mysource.imgix.net/demo.png",
+        loading: "lazy",
+      };
+      sut = shallow(
+        <Imgix
+          src={"https://mysource.imgix.net/demo.png"}
+          sizes="100vw"
+          width={100}
+          height={100}
+          htmlAttributes={htmlAttributes}
+        />
+      );
+      expect(sut.props()["sizes"]).toEqual("100vw"); 
     });
   });
 });


### PR DESCRIPTION
This PR makes two minor changes to `react-imgix`:

1) It updates the documentation to prioritize browser-level lazy loading using the loading="lazy" attribute. This approach is [well-supported by browsers](https://caniuse.com/loading-lazy-attr), and removes the need for external JavaScript libraries.
2) It adds a small piece of additional functionality to optimize the sizes attribute by prepending `"auto, "` to the `sizes` attribute when `loading="lazy"` is used, and the image does not have a height and width specified. The latter condition is because when both height and width are specified, the image is treated as fixed size, and gets a DPR-dependent srcset, which does not benefit from `sizes="auto"`. 

The `sizes="auto"` optimization allows supporting browsers to automatically select the proper size for the image at runtime, based on layout information. It will nearly always be more precise than a user-provided value. It is currently supported only on Chromium browsers, but non-supporting browsers simply ignore the value, so this change will have no negative impact on those browsers.

This is a non-breaking change.

Note:
I opted to be fairly conservative in when the `"auto, "` value is prepended. It treats `height` and `width` in either the element props or the htmlAttributes as defining a fixed image, and it doesn't supply "auto" as a default value if no `sizes` is present. I believe this is the correct thing to do since the library already raises a warning if `sizes` is not provided for a non-fixed image.

CC: @luqven, who I spoke with earlier about this proposed change 

## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [X] Read the [contributing guidelines](CONTRIBUTING.md).
- [X] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [X] Update the readme (if applicable).
- [X] Update or add any necessary API documentation (if applicable)
- [X] All existing unit tests are still passing (if applicable).

<!-- For new feature and bugfix Pull Requests-->

- [X] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [X] Add new passing unit tests to cover the code introduced by your PR (if applicable).
- [X] Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.
- [X] If this is a big feature with breaking changes, consider opening an issue to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
