### PR TITLE
chore: update Node.js version in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: yarn build
   deploy:
     docker:
-      - image: cimg/node:21.4
+      - image: cimg/node:current
     steps:
       - checkout
       - node/install-packages


### PR DESCRIPTION
## Description

semantic-release doesn't complete right now.
deploy step abruptly stops after this line log:
`(node:399) [DEP0174] DeprecationWarning: Calling promisify on a function that returns a Promise is likely a mistake.`

<!-- Steps to test: either provide a code snippet that exhibits this change or a link to a codepen/codesandbox demo -->

## Checklist

<!-- Please ensure you've completed this checklist before submitting a PR. If
You're not submitting a bugfix or feature, delete that part of the checklist.
-->

<!-- For all Pull Requests -->

- [ ] Read the [contributing guidelines](CONTRIBUTING.md).
- [ ] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [ ] Update the readme (if applicable).
- [ ] Update or add any necessary API documentation (if applicable)
- [ ] All existing unit tests are still passing (if applicable).

<!-- For new feature and bugfix Pull Requests-->

- [ ] Add some [steps](#steps-to-test) so we can test your bug fix or feature (if applicable).
- [ ] Add new passing unit tests to cover the code introduced by your PR (if applicable).
- [ ] Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.
- [ ] If this is a big feature with breaking changes, consider opening an issue to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
